### PR TITLE
Helm chart for Hydra

### DIFF
--- a/helm/README.md
+++ b/helm/README.md
@@ -1,0 +1,24 @@
+# Using Hydra Helm chart for Kubernetes
+
+## Requirements
+
+Pass the following values to Helm runtime when deploying your Hydra service:
+
+- `db.secretName` of a `Secret` resource `username` and `password`
+  keys (base64 encoded; using `kubectl` or [manually][k8s-base64])
+- `systemSecret` name of a `Secret` resource with a `system` key
+  containing Hydra system secret.
+
+TODO: Describe the deployment process and requirements
+
+## Security
+
+TODO: Describe the security measures
+
+## Deployment
+
+Use `strategy.autoMigrate` to add an `initContainer` that will run `hydra sql migrate` on startup.
+
+Choose between singleton (admin & public in one) and separate deployment by setting `strategy.singleton` to `true` or `false` accordingly.
+
+[k8s-base64]: https://kubernetes.io/docs/concepts/configuration/secret/#creating-a-secret-manually

--- a/helm/hydra/.helmignore
+++ b/helm/hydra/.helmignore
@@ -1,0 +1,22 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/helm/hydra/.rendered.yaml
+++ b/helm/hydra/.rendered.yaml
@@ -72,7 +72,7 @@ spec:
             - name: SYSTEM_SECRET
               valueFrom:
                 secretKeyRef:
-                  name: hydra-secret
+                  name: hydra-system-secret
                   key: system
       containers:
         - name: "hydra-public"
@@ -109,7 +109,7 @@ spec:
             - name: SYSTEM_SECRET
               valueFrom:
                 secretKeyRef:
-                  name: hydra-secret
+                  name: hydra-system-secret
                   key: system
 
         - name: "hydra-admin"
@@ -146,7 +146,7 @@ spec:
             - name: SYSTEM_SECRET
               valueFrom:
                 secretKeyRef:
-                  name: hydra-secret
+                  name: hydra-system-secret
                   key: system#
     #
     #

--- a/helm/hydra/.rendered.yaml
+++ b/helm/hydra/.rendered.yaml
@@ -1,0 +1,153 @@
+---
+# Source: hydra/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/name: hydra
+    helm.sh/chart: hydra-0.0.1
+    app.kubernetes.io/managed-by: Tiller
+    app.kubernetes.io/instance: hydra
+  name: hydra
+spec:
+# Provides options for the service so chart users have the full choice
+  type: "ClusterIP"
+  ports:
+    - name: http
+      port: 80
+      protocol: TCP
+      targetPort: 4444
+  selector:
+    app.kubernetes.io/name: hydra
+    app.kubernetes.io/instance: hydra
+
+---
+# Source: hydra/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: hydra
+  labels:
+    app.kubernetes.io/name: hydra
+    helm.sh/chart: hydra-0.0.1
+    app.kubernetes.io/version: 0.0.1
+    app.kubernetes.io/instance: hydra
+    app.kubernetes.io/managed-by: Tiller
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: hydra
+      app.kubernetes.io/instance: hydra
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: hydra
+        app.kubernetes.io/instance: hydra
+    spec:
+      initContainers:
+        - name: hydra-migrate
+          image: "oryd/hydra:v1.0.0-rc.8_oryOS.10"
+          imagePullPolicy: IfNotPresent
+          command: ["hydra"]
+          args: [
+              "migrate",
+              "sql",
+              "postgres://$(DB_USERNAME):$(DB_PASSWORD)@$(DB_HOST):$(DB_PORT)/$(DB_NAME)"
+            ]
+          envFrom:
+            - configMapRef:
+                name: "hydra-env"
+          env:
+            - name: DB_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: hydra-db-secrets
+                  key: username
+            - name: DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: hydra-db-secrets
+                  key: password
+            - name: SYSTEM_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: hydra-secret
+                  key: system
+      containers:
+        - name: "hydra-public"
+          image: "oryd/hydra:v1.0.0-rc.8_oryOS.10"
+          imagePullPolicy: IfNotPresent
+          command: ["hydra"]
+          args: ["serve", "public"]
+          livenessProbe:
+            httpGet:
+              path: "/health/alive"
+              port: "http"
+          readinessProbe:
+            httpGet:
+              path: "/health/ready"
+              port: "http"
+          ports:
+            - name: "http-public"
+              containerPort: 4444
+              protocol: TCP
+          envFrom:
+            - configMapRef:
+                name: "hydra-env"
+          env:
+            - name: DB_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: hydra-db-secrets
+                  key: username
+            - name: DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: hydra-db-secrets
+                  key: password
+            - name: SYSTEM_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: hydra-secret
+                  key: system
+
+        - name: "hydra-admin"
+          image: "oryd/hydra:v1.0.0-rc.8_oryOS.10"
+          imagePullPolicy: IfNotPresent
+          command: ["hydra"]
+          args: ["serve", "admin"]
+          livenessProbe:
+            httpGet:
+              path: "/health/alive"
+              port: "http"
+          readinessProbe:
+            httpGet:
+              path: "/health/ready"
+              port: "http"
+          ports:
+            - name: "http-admin"
+              containerPort: 4445
+              protocol: TCP
+          envFrom:
+            - configMapRef:
+                name: "hydra-env"
+          env:
+            - name: DB_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: hydra-db-secrets
+                  key: username
+            - name: DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: hydra-db-secrets
+                  key: password
+            - name: SYSTEM_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: hydra-secret
+                  key: system#
+    #
+    #
+

--- a/helm/hydra/Chart.yaml
+++ b/helm/hydra/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+appVersion: "0.0.1"
+description: A Helm chart for deploying Hydra in Kubernetes
+name: hydra
+version: 0.0.1

--- a/helm/hydra/templates/_helpers.tpl
+++ b/helm/hydra/templates/_helpers.tpl
@@ -1,0 +1,83 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "hydra.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "hydra.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "hydra.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "hydra.image" -}}
+{{- $tag := .Values.image.tag -}}
+{{- if kindIs "string" .Values.image.oryOS -}}
+  {{- $tag = printf "%s_oryOS.%s" $tag .Values.image.oryOS -}}
+{{- else if kindIs "float64" .Values.image.oryOS -}}
+  {{- $tag = printf "%s_oryOS.%s" $tag (toString .Values.image.oryOS) -}}
+{{- end -}}
+{{- trimSuffix ":" (printf "%s:%s" .Values.image.repository $tag) | quote -}}
+{{- end -}}
+
+{{- define "hydra.env" -}}
+{{- printf "%s-env" .Release.Name | quote -}}
+{{- end -}}
+
+
+{{- define "hydra.health" -}}
+livenessProbe:
+  httpGet:
+    path: "/health/alive"
+    port: "http"
+readinessProbe:
+  httpGet:
+    path: "/health/ready"
+    port: "http"
+{{- end -}}
+
+{{- define "hydra.secrets" -}}
+- name: DB_USERNAME
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Values.db.secretName }}
+      key: username
+- name: DB_PASSWORD
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Values.db.secretName }}
+      key: password
+- name: SYSTEM_SECRET
+  valueFrom:
+    secretKeyRef:
+      name: hydra-secret
+      key: system
+{{- end -}}
+
+{{- define "hydra.ports.public" -}}
+{{ default 4444 .Values.publicPort }}
+{{- end -}}
+{{- define "hydra.ports.admin" -}}
+{{ default 4445 .Values.adminPort }}
+{{- end -}}

--- a/helm/hydra/templates/_helpers.tpl
+++ b/helm/hydra/templates/_helpers.tpl
@@ -71,7 +71,7 @@ readinessProbe:
 - name: SYSTEM_SECRET
   valueFrom:
     secretKeyRef:
-      name: hydra-secret
+      name: {{ required "Hydra Helm chart requires `systemSecretName` to be specifed and persisted in Kubernetes. See README for more information" .Values.systemSecretName }}
       key: system
 {{- end -}}
 

--- a/helm/hydra/templates/deployment.yaml
+++ b/helm/hydra/templates/deployment.yaml
@@ -1,0 +1,96 @@
+{{- $connectionString := "postgres://$(DB_USERNAME):$(DB_PASSWORD)@$(DB_HOST):$(DB_PORT)/$(DB_NAME)" -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "hydra.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "hydra.name" . }}
+    helm.sh/chart: {{ include "hydra.chart" . }}
+    app.kubernetes.io/version: {{ .Chart.Version }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "hydra.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ include "hydra.name" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+    spec:
+      {{- if .Values.strategy.autoMigrate }}
+      initContainers:
+        - name: hydra-migrate
+          image: {{ include "hydra.image" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command: ["hydra"]
+          args: [
+              "migrate",
+              "sql",
+              {{ $connectionString | quote }}
+            ]
+          envFrom:
+            - configMapRef:
+                name: {{ printf "%s-env" .Release.Name | quote }}
+          env:
+          {{- include "hydra.secrets" . | nindent 12 }}
+      {{- end }}
+      containers:
+      {{- if .Values.singleton -}}
+        - name: {{ include "hydra.name" . }}
+          image: {{ include "hydra.image" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command: ["hydra"]
+          args: ["serve", "both"]
+          envFrom:
+          - configMapRef:
+              name: {{- include "hydra.env" . -}}
+          ports:
+            - name: http
+              containerPort: 80
+              protocol: TCP
+          {{- include "hydra.health" . | nindent 10 }}
+          ports:
+            - name: "http"
+              containerPort: {{ include "hydra.ports.public" . }}
+              protocol: TCP
+          env:
+          {{- include "hydra.secrets" . | nindent 12 }}
+
+      {{- else }}
+        - name: {{ printf "%s-public" (include "hydra.name" .) | quote }}
+          image: {{ include "hydra.image" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command: ["hydra"]
+          args: ["serve", "public"]
+          {{- include "hydra.health" . | nindent 10 }}
+          ports:
+            - name: "http-public"
+              containerPort: {{ include "hydra.ports.public" . }}
+              protocol: TCP
+          envFrom:
+            - configMapRef:
+                name: {{ include "hydra.env" . }}
+          env:
+          {{- include "hydra.secrets" . | nindent 12 }}
+
+        - name: {{ printf "%s-admin" (include "hydra.name" .) | quote }}
+          image: {{ include "hydra.image" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command: ["hydra"]
+          args: ["serve", "admin"]
+          {{- include "hydra.health" . | nindent 10 }}
+          ports:
+            - name: "http-admin"
+              containerPort: {{ include "hydra.ports.admin" . }}
+              protocol: TCP
+          envFrom:
+            - configMapRef:
+                name: {{ include "hydra.env" . }}
+          env:
+          {{- include "hydra.secrets" . | nindent 12 }}
+
+      {{- end -}}

--- a/helm/hydra/templates/deployment.yaml
+++ b/helm/hydra/templates/deployment.yaml
@@ -39,12 +39,11 @@ spec:
           {{- include "hydra.secrets" . | nindent 12 }}
       {{- end }}
       containers:
-      {{- if .Values.singleton -}}
         - name: {{ include "hydra.name" . }}
           image: {{ include "hydra.image" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: ["hydra"]
-          args: ["serve", "both"]
+          args: ["serve", "all"]
           envFrom:
           - configMapRef:
               name: {{- include "hydra.env" . -}}
@@ -59,38 +58,3 @@ spec:
               protocol: TCP
           env:
           {{- include "hydra.secrets" . | nindent 12 }}
-
-      {{- else }}
-        - name: {{ printf "%s-public" (include "hydra.name" .) | quote }}
-          image: {{ include "hydra.image" . }}
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
-          command: ["hydra"]
-          args: ["serve", "public"]
-          {{- include "hydra.health" . | nindent 10 }}
-          ports:
-            - name: "http-public"
-              containerPort: {{ include "hydra.ports.public" . }}
-              protocol: TCP
-          envFrom:
-            - configMapRef:
-                name: {{ include "hydra.env" . }}
-          env:
-          {{- include "hydra.secrets" . | nindent 12 }}
-
-        - name: {{ printf "%s-admin" (include "hydra.name" .) | quote }}
-          image: {{ include "hydra.image" . }}
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
-          command: ["hydra"]
-          args: ["serve", "admin"]
-          {{- include "hydra.health" . | nindent 10 }}
-          ports:
-            - name: "http-admin"
-              containerPort: {{ include "hydra.ports.admin" . }}
-              protocol: TCP
-          envFrom:
-            - configMapRef:
-                name: {{ include "hydra.env" . }}
-          env:
-          {{- include "hydra.secrets" . | nindent 12 }}
-
-      {{- end -}}

--- a/helm/hydra/templates/service.yaml
+++ b/helm/hydra/templates/service.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Service
+metadata:
+  {{- if .Values.service.annotations }}
+  annotations:
+    {{- toYaml .Values.service.annotations | nindent 4 }}
+  {{- end }}
+  labels:
+    app.kubernetes.io/name: {{ template "hydra.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  name: {{ template "hydra.fullname" . }}
+spec:
+# Provides options for the service so chart users have the full choice
+  type: {{ .Values.service.type | quote }}
+  ports:
+    - name: http
+      port: {{ .Values.service.port }}
+      protocol: TCP
+      targetPort: {{ include "hydra.ports.public" . }}
+      {{- if (and (eq .Values.service.type "NodePort") (not (empty .Values.service.nodePort))) }}
+      nodePort: {{ .Values.service.nodePort }}
+      {{- end }}
+  selector:
+    app.kubernetes.io/name: {{ template "hydra.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}

--- a/helm/hydra/values.yaml
+++ b/helm/hydra/values.yaml
@@ -1,0 +1,53 @@
+# Default values for hydra.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+
+image: # always specify using an FQN notation with optional "oryOS" key
+  repository: oryd/hydra
+  tag: v1.0.0-rc.8
+  oryOS: 10
+  pullPolicy: IfNotPresent
+
+db:
+  # host: # DB system hostname, defaults to "data"
+  # port: # DB system port, defaults to 3000
+  # name: # name of the Database, defaults to "hydra"
+  secretName: "hydra-db-secrets" # must be a Kubernetes secret in Hydra namespace wuth "username" & "password" keys
+
+systemSecret: "hydra-system-secrets" # must be a Kubernetes secret in Hydra namespace with a "system" key
+
+strategy:
+  autoMigrate: true
+  singleton: true
+
+# adminPort: # hydra default 4444
+# publicPort: # hydra default 4445
+
+nameOverride: ""
+fullnameOverride: ""
+
+service:
+  type: ClusterIP
+  port: 80
+
+# resources: {}
+
+
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #  cpu: 100m
+  #  memory: 128Mi
+  # requests:
+  #  cpu: 100m
+  #  memory: 128Mi
+
+# nodeSelector: {}
+
+# tolerations: []
+
+# affinity: {}

--- a/helm/hydra/values.yaml
+++ b/helm/hydra/values.yaml
@@ -7,7 +7,7 @@ replicaCount: 1
 image: # always specify using an FQN notation with optional "oryOS" key
   repository: oryd/hydra
   tag: v1.0.0-rc.8
-  oryOS: 10
+  oryOS: 10 # optional: specify OS version for Ory ecosystem; this is advised for is using this chart to deploy Oathkeeper or Keto
   pullPolicy: IfNotPresent
 
 db:
@@ -20,7 +20,6 @@ db:
 
 strategy:
   autoMigrate: true
-  singleton: true
 
 # adminPort: # hydra default 4444
 # publicPort: # hydra default 4445

--- a/helm/hydra/values.yaml
+++ b/helm/hydra/values.yaml
@@ -16,7 +16,7 @@ db:
   # name: # name of the Database, defaults to "hydra"
   secretName: "hydra-db-secrets" # must be a Kubernetes secret in Hydra namespace wuth "username" & "password" keys
 
-systemSecret: "hydra-system-secrets" # must be a Kubernetes secret in Hydra namespace with a "system" key
+# systemSecretName: # name of the k8s Secret resource in Hydra's target namespace with a "system" key containing the secret
 
 strategy:
   autoMigrate: true


### PR DESCRIPTION
WIP — you can see current state of the chart in `.rendered.yaml` file.

- [ ] Implement Kubernetes scalability controls
- [ ] Add Helm charts for each of oryOS components, individually deployable as well as set as Helm sub-chart dependencies of the main Hydra chart.
- [ ] Adopt new Hydra `yaml` configuration as a `ConfigMap` file embedding — e.g.
  ```yaml
  apiVersion: v1
  kind: ConfigMap
  data:
    ".hydra.yaml": |-
      serve:
        public:
          port: 4444
      ...
  ```
  or use `{{ tpl }}` function to pre-generate yaml resource file:
  ```yaml
  apiVersion: v1
  kind: ConfigMap
  data:
    ".hydra.yaml": |-
       {{- tpl (.Files.Get "resources/.hydra.yaml.tpl") . | nindent 4 }}
  ```
- [ ] Find a way to run `helm template` command generating `.rendered.yaml` snapshot and commit it from the CI

as per request in Discord on 03/30/2019


Non-goals (will be accomplished in the follow-up PRs):
- usage of Helm test utilities
- dependency on and compatibility with non-Ory charts (databases, ambassador proxy, istio, etc.)
- compatibility with global Chart repo — after we're done with v0.1.0 we can push it there to start getting feedback of the community at-large