### PR TITLE
helm/oathkeeper: add extraConfigFiles and extraEnv

### DIFF
--- a/docs/helm/oathkeeper.md
+++ b/docs/helm/oathkeeper.md
@@ -82,3 +82,20 @@ $ helm install \
 
 Please note that any configuration values set for `oathkeeper.config.access_rules.repositories` using e.g.
 a configuration file will be overwritten by this setting.
+
+### Additional configuration files and environment variables
+
+If you need more flexibility with configuration files (e.g. multiple access rules, access rules in YAML format, etc),
+you can use `extraConfigFiles` to pass additional configs via values-file or helm flags.
+
+You can also provide additional environment variables using `extraEnv`.
+
+Example:
+
+```bash
+$ helm install ory/oathkeeper \
+    --set "extraConfigFiles[0].name=more-access-rules.yaml" \
+    --set-file "extraConfigFiles[0].contents=additional_access_rules.yaml" \
+    --set "extraEnv[0].name=ACCESS_RULES_REPOSITORIES" \
+    --set "extraEnv[0].value=file:///etc/config/access-rules.json,file:///etc/config/more-access-rules.yaml"
+```

--- a/helm/charts/oathkeeper/Chart.yaml
+++ b/helm/charts/oathkeeper/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: "v0.16.0-beta.4_oryOS.12"
+appVersion: "v0.17.0-beta.1"
 description: A Helm chart for deployoing ORY Oathkeeper in Kubernetes
 name: oathkeeper
 version: 0.0.1

--- a/helm/charts/oathkeeper/templates/configmap.yaml
+++ b/helm/charts/oathkeeper/templates/configmap.yaml
@@ -59,4 +59,7 @@ data:
 {{- with .Values.oathkeeper.config -}}
   {{- toYaml . | nindent 4 }}
 {{- end -}}
+{{- range $item := .Values.extraConfigFiles }}
+  {{ $item.name }}: |- {{ $item.contents | nindent 4 }}
+{{- end }}
 {{- end -}}

--- a/helm/charts/oathkeeper/templates/deployment.yaml
+++ b/helm/charts/oathkeeper/templates/deployment.yaml
@@ -44,6 +44,9 @@ spec:
             - name: ACCESS_RULES_REPOSITORIES
               value: "file:///etc/config/access-rules.json"
             {{- end }}
+            {{- if .Values.extraEnv }}
+            {{- toYaml .Values.extraEnv | nindent 12 }}
+            {{- end }}
           volumeMounts:
             - name: {{ include "oathkeeper.name" . }}-config-volume
               mountPath: /etc/config

--- a/helm/charts/oathkeeper/values.yaml
+++ b/helm/charts/oathkeeper/values.yaml
@@ -111,3 +111,19 @@ tolerations: []
 
 # Configure node affinity
 affinity: {}
+
+# Extra config files that will be put to the volume at "/etc/config".
+# For example, you can define multiple additional access rules files.
+extraConfigFiles: []
+  # Example:
+  # - name: access-rules.yaml
+  #   contents: |
+  #     - id: management-api
+  #       authenticators:
+  #         - handler: noop
+
+# Extra environment variables that will be passed to the container.
+extraEnv: []
+  # Example:
+  # - name: ACCESS_RULES_REPOSITORIES
+  #   value: file:///etc/config/access-rules.yaml


### PR DESCRIPTION
## Proposed changes

This commit adds more flexibility in oathkeeper helm chart
configuration. Now any number of additional configs and environment
variables can be passed.

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.md)
- [x] I have read the [security policy](SECURITY.md)
- [x] I confirm that this pull request does not address a security vulnerability. If this pull request addresses a security
vulnerability, I confirm that I got green light (please contact [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push the changes.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation within the code base (if appropriate)
