### PR TITLE
Make annotations for the hydra deployment configurable 

### DIFF
--- a/helm/charts/hydra/templates/deployment.yaml
+++ b/helm/charts/hydra/templates/deployment.yaml
@@ -16,10 +16,10 @@ spec:
       labels:
         app.kubernetes.io/name: {{ include "hydra.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
-        {{- with .Values.deployment.annotations }}
-        annotations:
-          {{- toYaml . | nindent 4 }}
-        {{- end }}
+      {{- with .Values.deployment.annotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     spec:
     {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/helm/charts/hydra/templates/deployment.yaml
+++ b/helm/charts/hydra/templates/deployment.yaml
@@ -16,6 +16,10 @@ spec:
       labels:
         app.kubernetes.io/name: {{ include "hydra.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
+        {{- with .Values.deployment.annotations }}
+        annotations:
+          {{- toYaml . | nindent 4 }}
+        {{- end }}
     spec:
     {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/helm/charts/hydra/values.yaml
+++ b/helm/charts/hydra/values.yaml
@@ -106,6 +106,12 @@ deployment:
   #    cpu: 100m
   #  memory: 128Mi
 
+  annotations: {}
+  #      If you do want to specify annotations, uncomment the following
+  #      lines, adjust them as necessary, and remove the curly braces after 'annotations:'.
+  #      e.g.  sidecar.istio.io/rewriteAppHTTPProbers: "true"
+
+
   # Node labels for pod assignment.
   nodeSelector: {}
   # If you do want to specify node labels, uncomment the following

--- a/helm/charts/hydra/values.yaml
+++ b/helm/charts/hydra/values.yaml
@@ -111,11 +111,10 @@ deployment:
   #      lines, adjust them as necessary, and remove the curly braces after 'annotations:'.
   #      e.g.  sidecar.istio.io/rewriteAppHTTPProbers: "true"
 
-
   # Node labels for pod assignment.
   nodeSelector: {}
   # If you do want to specify node labels, uncomment the following
-  # lines, adjust them as necessary, and remove the curly braces after 'annotations:'.
+  # lines, adjust them as necessary, and remove the curly braces after 'nodeSelector:'.
   #   foo: bar
 
   # Configure node tolerations.


### PR DESCRIPTION
## Proposed changes
The current chart wasn't allowing to configure the deployment template's annotations, which becomes a problem in some setups. In order to allow to configure annotations such as Istio's `rewriteAppHTTPProbers` the chart for Hydra needs to provide a way to do so. 
We added a key to the `deployment` section with the name `annotations` and extended the template. The actual implementation is the same as it was already done for the Ingress templates.

## Checklist
- [x] I have read the [contributing guidelines](CONTRIBUTING.md)
- [x] I have read the [security policy](SECURITY.md)
- [x] I confirm that this pull request does not address a security vulnerability. If this pull request addresses a security
vulnerability, I confirm that I got green light (please contact [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push the changes.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation within the code base (if appropriate)
