### PR TITLE
Update YAML k8 file for changes in Kubernetes 1.16

### DIFF
--- a/yaml/oathkeeper/simple/oathkeeper-api.yaml
+++ b/yaml/oathkeeper/simple/oathkeeper-api.yaml
@@ -30,7 +30,7 @@ spec:
     spec:
       containers:
       - name: ory-oathkeeper
-        image: oryd/oathkeeper:latest
+        image: oryd/oathkeeper:v0.13.8_oryOS.8
         imagePullPolicy: Always
         command: ["oathkeeper", "serve", "api"]
         env:

--- a/yaml/oathkeeper/simple/oathkeeper-api.yaml
+++ b/yaml/oathkeeper/simple/oathkeeper-api.yaml
@@ -12,12 +12,15 @@ spec:
     name: http-ory-oathkeeper
     targetPort: http-api
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: ory-oathkeeper
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: ory-oathkeeper
   strategy:
     type: RollingUpdate
   template:
@@ -27,7 +30,7 @@ spec:
     spec:
       containers:
       - name: ory-oathkeeper
-        image: oryd/oathkeeper:v0.13.8_oryOS.8
+        image: oryd/oathkeeper:latest
         imagePullPolicy: Always
         command: ["oathkeeper", "serve", "api"]
         env:


### PR DESCRIPTION
Updated the apiVersion to apps/v1 for the Deployment
Set the image to latest and added the selector field.

## Related issue
No GitHub issue but came across this issue while deploying Oathkeeper in Kubernetes.

In the latest version of Kubernetes (1.16) there was a breaking change which moved the Deployment kind out of beta. [https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/](https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/)

## Proposed changes

I changed the apiVersion to apps/v1 instead of extensions/v1beta1. And to prevent another error also added a selector matchLabel.
Another change to make sure everything stays up to date is to change the image version to latest instead of version 0.13.

These changes allow this file to work again.

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
- [x] I have read the [security policy](../security/policy)
- [x] I confirm that this pull request does not address a security vulnerability. If this pull request addresses a security
vulnerability, I confirm that I got green light (please contact [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push the changes.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation within the code base (if appropriate)

## Further comments
For now I changed the image to latest so that this file doesn't have to be changed with every release. Feedback on this is welcome.
