### PR TITLE
Configurable annotations for services

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,10 +23,9 @@ jobs:
           command: |
             sudo apt-get update 
             sudo apt-get -y install snapd
-            sudo snap install microk8s --classic
-            sudo snap install kubectl --classic
+            sudo snap install microk8s --channel=1.13/stable --classic
+            sudo snap alias microk8s.kubectl kubectl
             snap info microk8s
-            sudo usermod -a -G microk8s circleci
       - run:
           name: "System setup"
           command: |
@@ -36,9 +35,9 @@ jobs:
       - run:
           name: "Start microk8s"
           command: |
-            microk8s.start
-            microk8s.status
-            microk8s.enable dns
+            sudo microk8s.start
+            sudo microk8s.status --wait-ready
+            sudo microk8s.enable dns
             kubectl get all --all-namespaces
       - run: 
           name: "Install Helm"

--- a/docs/helm/hydra.md
+++ b/docs/helm/hydra.md
@@ -82,7 +82,7 @@ by creating a yaml file with key `hydra.config`
 ```yaml
 # hydra-config.yaml
 
-oathkeeper:
+hydra:
   config:
     # e.g.:
     ttl:

--- a/helm/charts/example-idp/templates/service.yaml
+++ b/helm/charts/example-idp/templates/service.yaml
@@ -4,6 +4,10 @@ metadata:
   name: {{ include "example-idp.fullname" . }}
   labels:
 {{ include "example-idp.labels" . | indent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/helm/charts/example-idp/values.yaml
+++ b/helm/charts/example-idp/values.yaml
@@ -14,6 +14,11 @@ fullnameOverride: ""
 service:
   type: ClusterIP
   port: 3000
+  # If you do want to specify annotations, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'annotations:'.
+  annotations: {}
+  # kubernetes.io/ingress.class: nginx
+  # kubernetes.io/tls-acme: "true"
 
 ingress:
   enabled: false

--- a/helm/charts/hive/templates/service-admin.yaml
+++ b/helm/charts/hive/templates/service-admin.yaml
@@ -6,6 +6,10 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
 {{ include "hive.labels" . | indent 4 }}
+  {{- with .Values.service.admin.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   type: {{ .Values.service.admin.type }}
   ports:

--- a/helm/charts/hive/templates/service-public.yaml
+++ b/helm/charts/hive/templates/service-public.yaml
@@ -6,6 +6,10 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
 {{ include "hive.labels" . | indent 4 }}
+  {{- with .Values.service.public.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   type: {{ .Values.service.public.type }}
   ports:

--- a/helm/charts/hive/values.yaml
+++ b/helm/charts/hive/values.yaml
@@ -18,10 +18,21 @@ service:
     enabled: true
     type: ClusterIP
     port: 80
+    # If you do want to specify annotations, uncomment the following
+    # lines, adjust them as necessary, and remove the curly braces after 'annotations:'.
+    annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
   public:
     enabled: true
     type: ClusterIP
     port: 80
+    # If you do want to specify annotations, uncomment the following
+    # lines, adjust them as necessary, and remove the curly braces after 'annotations:'.
+    annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+
 
 ingress:
   admin:

--- a/helm/charts/hydra/templates/service-admin.yaml
+++ b/helm/charts/hydra/templates/service-admin.yaml
@@ -6,6 +6,10 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
 {{ include "hydra.labels" . | indent 4 }}
+  {{- with .Values.service.admin.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   type: {{ .Values.service.admin.type }}
   ports:

--- a/helm/charts/hydra/templates/service-public.yaml
+++ b/helm/charts/hydra/templates/service-public.yaml
@@ -6,6 +6,10 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
 {{ include "hydra.labels" . | indent 4 }}
+  {{- with .Values.service.public.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   type: {{ .Values.service.public.type }}
   ports:

--- a/helm/charts/hydra/values.yaml
+++ b/helm/charts/hydra/values.yaml
@@ -26,6 +26,11 @@ service:
     type: ClusterIP
     # The service port
     port: 4444
+    # If you do want to specify annotations, uncomment the following
+    # lines, adjust them as necessary, and remove the curly braces after 'annotations:'.
+    annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
   # Configures the Kubernetes service for the api port.
   admin:
     # En-/disable the service
@@ -34,6 +39,11 @@ service:
     type: ClusterIP
     # The service port
     port: 4445
+    # If you do want to specify annotations, uncomment the following
+    # lines, adjust them as necessary, and remove the curly braces after 'annotations:'.
+    annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
 
 # Configure ingress
 ingress:

--- a/helm/charts/oathkeeper/templates/service-api.yaml
+++ b/helm/charts/oathkeeper/templates/service-api.yaml
@@ -8,6 +8,10 @@ metadata:
   {{- end }}
   labels:
 {{ include "oathkeeper.labels" . | indent 4 }}
+  {{- with .Values.service.api.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   type: {{ .Values.service.api.type }}
   ports:

--- a/helm/charts/oathkeeper/templates/service-proxy.yaml
+++ b/helm/charts/oathkeeper/templates/service-proxy.yaml
@@ -8,6 +8,10 @@ metadata:
   {{- end }}
   labels:
 {{ include "oathkeeper.labels" . | indent 4 }}
+  {{- with .Values.service.proxy.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   type: {{ .Values.service.proxy.type }}
   ports:

--- a/helm/charts/oathkeeper/values.yaml
+++ b/helm/charts/oathkeeper/values.yaml
@@ -30,6 +30,11 @@ service:
     type: ClusterIP
     # The service port
     port: 4455
+    # If you do want to specify annotations, uncomment the following
+    # lines, adjust them as necessary, and remove the curly braces after 'annotations:'.
+    annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
   # Configures the Kubernetes service for the api port.
   api:
     # En-/disable the service
@@ -38,6 +43,11 @@ service:
     type: ClusterIP
     # The service port
     port: 4456
+    # If you do want to specify annotations, uncomment the following
+    # lines, adjust them as necessary, and remove the curly braces after 'annotations:'.
+    annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
 
 # Configure ingress
 ingress:

--- a/yaml/oathkeeper/simple/oathkeeper-api.yaml
+++ b/yaml/oathkeeper/simple/oathkeeper-api.yaml
@@ -30,7 +30,7 @@ spec:
     spec:
       containers:
       - name: ory-oathkeeper
-        image: oryd/oathkeeper:latest
+        image: oryd/oathkeeper:v0.13.8_oryOS.8
         imagePullPolicy: Always
         command: ["oathkeeper", "serve", "api"]
         env:

--- a/yaml/oathkeeper/simple/oathkeeper-api.yaml
+++ b/yaml/oathkeeper/simple/oathkeeper-api.yaml
@@ -12,12 +12,15 @@ spec:
     name: http-ory-oathkeeper
     targetPort: http-api
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: ory-oathkeeper
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: ory-oathkeeper
   strategy:
     type: RollingUpdate
   template:
@@ -27,7 +30,7 @@ spec:
     spec:
       containers:
       - name: ory-oathkeeper
-        image: oryd/oathkeeper:v0.13.8_oryOS.8
+        image: oryd/oathkeeper:latest
         imagePullPolicy: Always
         command: ["oathkeeper", "serve", "api"]
         env:


### PR DESCRIPTION
## Related issue
#57 
@aeneasr 

## Proposed changes

Allow for configurable annotations for the services to allow gateways (like Ambassador) to be configured through here instead of using CRDs.

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
- [x] I have read the [security policy](../security/policy)
- [x] I confirm that this pull request does not address a security vulnerability. If this pull request addresses a security
vulnerability, I confirm that I got green light (please contact [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push the changes.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation within the code base (if appropriate)

## Further comments

