### PR TITLE
Have hydra docs example say hydra instead of oath keeper

### DIFF
--- a/docs/helm/hydra.md
+++ b/docs/helm/hydra.md
@@ -82,7 +82,7 @@ by creating a yaml file with key `hydra.config`
 ```yaml
 # hydra-config.yaml
 
-oathkeeper:
+hydra:
   config:
     # e.g.:
     ttl:


### PR DESCRIPTION
The old version said oathkeeper in the configuration example. Changed this to say hydra

## Related issue
-

## Proposed changes
Change it to hydra to have a good example.

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
- [x] I have read the [security policy](../security/policy)
- [x] I confirm that this pull request does not address a security vulnerability. If this pull request addresses a security
vulnerability, I confirm that I got green light (please contact [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push the changes.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation within the code base (if appropriate)

## Further comments
