### PR TITLE
Fix hydra admin service name generator

### DIFF
--- a/helm/charts/hydra/charts/hydra-maester/templates/_helpers.tpl
+++ b/helm/charts/hydra/charts/hydra-maester/templates/_helpers.tpl
@@ -49,11 +49,11 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 Get Hydra admin service name
 */}}
 {{- define "hydra-maester.adminService" -}}
-{{- $fullName := include "hydra-maester.fullname" . -}}
-{{- $nameParts := split "-" $fullName }}
-{{- if eq $nameParts._0 $nameParts._1 -}}
-{{- printf "%s-admin" $nameParts._0 | trimSuffix "-" -}}
+{{- if .Values.hydraFullnameOverride -}}
+{{- printf "%s-admin"  .Values.hydraFullnameOverride -}}
+{{- else if contains "hydra" .Release.Name -}}
+{{- printf "%s-admin" .Release.Name -}}
 {{- else -}}
-{{- printf "%s-%s-admin" $nameParts._0 $nameParts._1 | trimSuffix "-" -}}
+{{- printf "%s-%s-admin" .Release.Name "hydra" -}}
 {{- end -}}
 {{- end -}}


### PR DESCRIPTION
## Related issue #91 @aeneasr 

## Proposed changes

To understand this change, one must know that the hydra chart doesn't include `hydra` in its resource name twice if it is already contained in the release name. This behaviour is defined in: `/helm/charts/hydra/templates/_helpers.tpl:14-22`
```
{{- define "hydra.fullname" -}}
{{- if .Values.fullnameOverride -}}
{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
{{- else -}}
{{- $name := default .Chart.Name .Values.nameOverride -}}
{{- if contains $name .Release.Name -}}
{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
{{- else -}}
{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
```
A release name like `hydra-test`, `test-hydra` or simply `hydra` results in the admin service ingress name `<Release.Name>-admin`. A realese name without hydra results in `<Release.Name>-hydra-admin`. So hydra's behaviour observed in #91 is intended and works fine.

Note that the name can be completly overriden using a local value <.Values.fullnameOverride>. If this variable is set, the resource name will be `<.Values.fullnameOverride>-admin`.

My conclusion was that the hydra-maester helmchart needs to reflect this behaviour in order to adjust it's confg. And indeed the _helpers file includes a function `Get hydra admin service name`. The function that is present doesn't reflect this behaviour though.

To fix the issue, this function needed to be changed.

Note that I added an additional Value called `hydraFullnameOverride` with which we can propagate the override of the fullname. in a values.yaml that would look like:
```
hydra:                                                                                         
  fullnameOverride: test                                                                       
  hydra-maester:                                                                               
    hydraFullnameOverride: test         
```

I tested the following release names:

```
hydra,
hydra-test
test-hydra
test-hydra (with fullnameOverride and hydraFullnameOverride set to test)
```
All worked as expected.

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
- [x] I have read the [security policy](../security/policy)
- [x] I confirm that this pull request does not address a security vulnerability. If this pull request addresses a security
vulnerability, I confirm that I got green light (please contact [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push the changes.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation within the code base (if appropriate)