### PR TITLE
Remove namespace as unsupported feature

### DIFF
--- a/helm/charts/hydra/charts/hydra-maester/templates/rbac.yaml
+++ b/helm/charts/hydra/charts/hydra-maester/templates/rbac.yaml
@@ -55,7 +55,6 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
   name: {{ include "hydra-maester.name" . }}-role-{{ .Release.Namespace }}
-  namespace: {{ .Release.Namespace }}
 
 {{- $name := include "hydra-maester.name" . -}}
 {{- $namespace := .Release.Namespace -}}


### PR DESCRIPTION
Remove namespace as unsupported feature for roleRef.
This change must fix error installing hydra via helm3.

## Related issue
#96 

