### PR TITLE
chore: Allow usage of existing secret in hydra chart

### DIFF
--- a/docs/helm/hydra.md
+++ b/docs/helm/hydra.md
@@ -13,7 +13,7 @@ To install ORY Hydra, the following values must be set
 * `hydra.config.urls.consent`
 * `hydra.config.secrets.system`
 
-> **NOTE:** If no `hydra.config.secrets.system` secrets are not supplied, a secret is generated automatically. The generated secret is cryptographically secure, and 32 signs long.
+> **NOTE:** If no `hydra.config.secrets.system` secrets is supplied and `hydra.existingSecret` is empty, a secret is generated automatically. The generated secret is cryptographically secure, and 32 signs long.
 
 If you wish to install ORY Hydra with an in-memory database, a cryptographically strong secret, a Login and Consent
 provider located at `https://my-idp/` run:
@@ -34,6 +34,21 @@ You can optionally also set the cookie secrets:
 $ helm install \
     ...
     'hydra.config.secrets.cookie=$(LC_ALL=C tr -dc 'A-Za-z0-9' < /dev/urandom | base64 | head -c 32)' \
+    ...
+    ory/hydra
+```
+
+Alternatively, you can use an existing kubernetes secret:
+
+```bash
+
+$ kubectl create secret generic my-secure-secret --from-literal=dsn=postgres://foo:bar@baz:1234/db \
+    --from-literal=secretsCookie=$(LC_ALL=C tr -dc 'A-Za-z0-9' < /dev/urandom | base64 | head -c 32) \
+    --from-literal=secretsSystem=$(LC_ALL=C tr -dc 'A-Za-z0-9' < /dev/urandom | base64 | head -c 32)
+
+$ helm install \
+    ...
+    'hydra.existingSecret=my-secure-secret' \
     ...
     ory/hydra
 ```

--- a/helm/charts/hydra/templates/_helpers.tpl
+++ b/helm/charts/hydra/templates/_helpers.tpl
@@ -67,6 +67,17 @@ memory
 {{- end -}}
 
 {{/*
+Generate the name of the secret resource containing secrets
+*/}}
+{{- define "hydra.secretname" -}}
+{{- if .Values.hydra.existingSecret -}}
+{{- .Values.hydra.existingSecret -}}
+{{- else -}}
+{{ include "hydra.fullname" . }}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Generate the secrets.system value
 */}}
 {{- define "hydra.secrets.system" -}}

--- a/helm/charts/hydra/templates/deployment.yaml
+++ b/helm/charts/hydra/templates/deployment.yaml
@@ -113,17 +113,17 @@ spec:
             - name: DSN
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "hydra.fullname" . }}
+                  name: {{ include "hydra.secretname" . }}
                   key: dsn
             - name: SECRETS_SYSTEM
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "hydra.fullname" . }}
+                  name: {{ include "hydra.secretname" . }}
                   key: secretsSystem
             - name: SECRETS_COOKIE
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "hydra.fullname" . }}
+                  name: {{ include "hydra.secretname" . }}
                   key: secretsCookie
           resources:
             {{- toYaml .Values.deployment.resources | nindent 12 }}

--- a/helm/charts/hydra/templates/secrets.yaml
+++ b/helm/charts/hydra/templates/secrets.yaml
@@ -1,7 +1,8 @@
+{{- if not .Values.hydra.existingSecret -}}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "hydra.fullname" . }}
+  name: {{ include "hydra.secretname" . }}
   namespace: {{ .Release.Namespace }}
   labels:
 {{ include "hydra.labels" . | indent 4 }}
@@ -15,3 +16,4 @@ data:
   secretsSystem: {{ ( include "hydra.secrets.system" . | default ( randAlphaNum 32 )) | required "Value secrets.system can not be empty!" | b64enc | quote }}
   secretsCookie: {{ ( include "hydra.secrets.cookie" . | default ( randAlphaNum 32 )) | required "Value secrets.cookie can not be empty!" | b64enc | quote }}
   dsn: {{ include "hydra.dsn" . | b64enc | quote }}
+{{- end -}}

--- a/helm/charts/hydra/values.yaml
+++ b/helm/charts/hydra/values.yaml
@@ -79,7 +79,6 @@ ingress:
 #        - api.hydra.local
 #      - secretName: hydra-api-example-tls
 
-
 # Configure ORY Hydra itself
 hydra:
   # The ORY Hydra configuration. For a full list of available settings, check:
@@ -96,6 +95,8 @@ hydra:
           - 172.16.0.0/12
           - 192.168.0.0/16
     secrets: {}
+    # Use a pre-existing secret (see secret.yaml for required fields)
+    # existingSecret: my-preexisting-secret
     urls:
       self: {}
 


### PR DESCRIPTION
Signed-off-by: Clément BUCHART <clement@buchart.dev>

## Proposed changes

Simply allow using an existing secret to configure hydra.
Our use-case is as follow : 
We create a Google CloudSQL and a gcloud-sqlproxy via terraform while setting up our infrastructure.
We deploy Hydra as part of our application stack.

We would like to be able to have terraform create the secrets containing the DataSourceName as part of the infrastructure setup, and have hydra pick the secret up during the application deploy step.

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
- [x] I have read the [security policy](../security/policy)
- [x] I confirm that this pull request does not address a security vulnerability. If this pull request addresses a security
vulnerability, I confirm that I got green light (please contact [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push the changes.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation within the code base (if appropriate)