### PR TITLE
make maester.adminService in hydra values.yaml a map to remove warning

### DIFF
--- a/helm/charts/hydra/values.yaml
+++ b/helm/charts/hydra/values.yaml
@@ -149,7 +149,7 @@ affinity: {}
 maester:
   enabled: true
   # Values for the hydra admin service arguments to hydra-maester
-  adminService:
+  adminService: {}
     # The service name value may need to be set if you use
     # `fullnameOverride` for the parent chart
     # name:


### PR DESCRIPTION
make maester.adminService in hydra values.yaml a map to remove coalesce warning

## Related issue

https://github.com/ory/k8s/issues/134

## Proposed changes

maester.adminService is map with two values (name and port). Not having `{}` causes a warning.

```
# Configures controller setup
maester:
  enabled: true
  # Values for the hydra admin service arguments to hydra-maester
  adminService: {}  # -----> instead of adminService:
    # The service name value may need to be set if you use
    # `fullnameOverride` for the parent chart
    # name:

    # You only need to set this port if you change the value for
    # `service.admin.port` in the parent chart
    # port:

```

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
- [x] I have read the [security policy](../security/policy)
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation within the code base (if appropriate)

