### PR TITLE
fix: service account name for maester sidecar

### DIFF
--- a/helm/charts/oathkeeper/templates/deployment-sidecar.yaml
+++ b/helm/charts/oathkeeper/templates/deployment-sidecar.yaml
@@ -115,7 +115,7 @@ spec:
             - name: {{ include "oathkeeper.name" . }}-rules-volume
               mountPath: /etc/rules
               readOnly: false
-      serviceAccountName: {{ include "oathkeeper-maester.name" . }}-maester-account
+      serviceAccountName: {{ default "maester" .Values.maester.nameOverride }}-account
       {{- with .Values.deployment.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}


### PR DESCRIPTION
## Related issue
Related to issue #136. We can discuss this issue on slack if you want.

## Proposed changes

Add a default value of `global.ory.oathkeeper.maester.name: maester` and edit the sidecar deployment's service account name to use to `{{ .Values.global.ory.oathkeeper.maester.name }}-account` 

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
- [x] I have read the [security policy](../security/policy)
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation within the code base (if appropriate)
