### PR TITLE
chore: Typo in configuration section

### DIFF
--- a/docs/helm/kratos.md
+++ b/docs/helm/kratos.md
@@ -33,7 +33,7 @@ $ helm install \
 
 ## Configuration
 
-You can pass your [ORY Hydra configuration file](https://www.ory.sh/kratos/docs/reference/configuration)
+You can pass your [ORY Kratos configuration file](https://www.ory.sh/kratos/docs/reference/configuration)
 by creating a yaml file with key `kratos.config`
 
 ```yaml


### PR DESCRIPTION
Stale reference to Hydra in Kratos helm doc