### PR TITLE
fix: update kratos' helm chart to use secrets.cookie

### DIFF
--- a/helm/charts/kratos/Chart.yaml
+++ b/helm/charts/kratos/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
-appVersion: "0.1.1-alpha.1"
+appVersion: "0.4.3-alpha.1"
 description: A ORY Kratos Helm chart for Kubernetes
 name: kratos
-version: 0.1.0
+version: 0.2.0
 type: application

--- a/helm/charts/kratos/templates/_helpers.tpl
+++ b/helm/charts/kratos/templates/_helpers.tpl
@@ -41,9 +41,9 @@ Generate the dsn value
 {{/*
 Generate the secrets.session value
 */}}
-{{- define "kratos.secrets.session" -}}
-{{- if .Values.kratos.config.secrets.session -}}
-{{- .Values.kratos.config.secrets.session }}
+{{- define "kratos.secrets.cookie" -}}
+{{- if .Values.kratos.config.secrets.cookie -}}
+{{- .Values.kratos.config.secrets.cookie }}
 {{- end -}}
 {{- end -}}
 

--- a/helm/charts/kratos/templates/_helpers.tpl
+++ b/helm/charts/kratos/templates/_helpers.tpl
@@ -39,7 +39,16 @@ Generate the dsn value
 {{- end -}}
 
 {{/*
-Generate the secrets.session value
+Generate the secrets.default value
+*/}}
+{{- define "kratos.secrets.default" -}}
+{{- if .Values.kratos.config.secrets.default -}}
+{{- .Values.kratos.config.secrets.default }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Generate the secrets.cookie value
 */}}
 {{- define "kratos.secrets.cookie" -}}
 {{- if .Values.kratos.config.secrets.cookie -}}

--- a/helm/charts/kratos/templates/deployment.yaml
+++ b/helm/charts/kratos/templates/deployment.yaml
@@ -57,11 +57,17 @@ spec:
                   name: {{ include "kratos.fullname" . }}
                   key: dsn
             -
-              name: SECRETS_SESSION
+              name: SECRETS_DEFAULT
               valueFrom:
                 secretKeyRef:
                   name: {{ include "kratos.fullname" . }}
-                  key: secretsSession
+                  key: secretsDefault
+            -
+              name: SECRETS_COOKIE
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "kratos.fullname" . }}
+                  key: secretsCookie
     {{- end}}
       volumes:
         -
@@ -95,11 +101,17 @@ spec:
                   name: {{ include "kratos.fullname" . }}
                   key: dsn
             -
-              name: SECRETS_SESSION
+              name: SECRETS_DEFAULT
               valueFrom:
                 secretKeyRef:
                   name: {{ include "kratos.fullname" . }}
-                  key: secretsSession
+                  key: secretsDefault
+            -
+              name: SECRETS_COOKIE
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "kratos.fullname" . }}
+                  key: secretsCookie
           ports:
             - name: http-admin
               containerPort: {{ .Values.kratos.config.serve.admin.port }}

--- a/helm/charts/kratos/templates/secrets.yaml
+++ b/helm/charts/kratos/templates/secrets.yaml
@@ -9,4 +9,4 @@ type: Opaque
 data:
   dsn: {{ include "kratos.dsn" . | b64enc | quote }}
   # Generate a random secret if the user doesn't give one. User given password has priority
-  secretsSession: {{ include "kratos.secrets.session" . | required "Value kratos.config.secrets.session can not be empty!" | b64enc | quote }}
+  secretsSession: {{ include "kratos.secrets.cookie" . | required "Value kratos.config.secrets.cookie can not be empty!" | b64enc | quote }}

--- a/helm/charts/kratos/templates/secrets.yaml
+++ b/helm/charts/kratos/templates/secrets.yaml
@@ -8,5 +8,6 @@ metadata:
 type: Opaque
 data:
   dsn: {{ include "kratos.dsn" . | b64enc | quote }}
-  # Generate a random secret if the user doesn't give one. User given password has priority
-  secretsSession: {{ include "kratos.secrets.cookie" . | required "Value kratos.config.secrets.cookie can not be empty!" | b64enc | quote }}
+  # Generate a random secret if the user doesn't give one. User given secret has priority
+  secretsDefault: {{ ( include "kratos.secrets.default" . | default ( randAlphaNum 32 )) | required "Value kratos.config.secrets.default can not be empty!" | b64enc | quote }}
+  secretsCookie: {{ ( include "kratos.secrets.cookie" . | default ( randAlphaNum 32 )) | required "Value kratos.config.secrets.cookie can not be empty!" | b64enc | quote }}

--- a/helm/charts/kratos/values.yaml
+++ b/helm/charts/kratos/values.yaml
@@ -79,8 +79,7 @@ kratos:
       admin:
         port: 4434
 
-    secrets:
-      session: []
+    secrets: {}
 
 deployment:
   resources: {}

--- a/helm/charts/kratos/values.yaml
+++ b/helm/charts/kratos/values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository:  oryd/kratos
-  tag: v0.1.1-alpha.1-sqlite
+  tag: v0.4.3-alpha.1-sqlite
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []


### PR DESCRIPTION
## Related issue

The current chart is not working with kratos@v0.4.3
closes #154 
closes #151 

## Proposed changes

Replaced the usage of `secrets.session` with `secrets.cookie` as the key was renamed.

## Further comments

Maybe we should also respect `secrets.default` as they can be used as a fallback for `sessions.cookie`.