### PR TITLE
fix: Update kratos ingress default values

### DIFF
--- a/helm/charts/kratos/values.yaml
+++ b/helm/charts/kratos/values.yaml
@@ -42,9 +42,7 @@ ingress:
     hosts:
       - host: kratos.admin.local.com
         paths:
-          - path: /
-            backend:
-              servicePort: 80
+          - /
 
     tls: []
     #  - secretName: chart-example-tls
@@ -59,9 +57,7 @@ ingress:
       -
         host: kratos.public.local.com
         paths:
-          - path: /
-            backend:
-              servicePort: 80
+          - /
 
     tls: []
     #  - secretName: chart-example-tls


### PR DESCRIPTION
## Proposed changes

Current templates for admin and public ingresses expect `ingress.admin.hosts.*.paths` and `ingress.public.hosts*.paths` values to be of `list(string)` type, but default values contain objects with `path` and `backend` fields.

```yaml
{{- range .paths }}
  - path: {{ . }}
     backend:
        serviceName: {{ $fullName }}-admin
        servicePort: http
{{- end }}
```

It could make sense to change templates themselves, but service ports are already named and configured separately.

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
- [x] I have read the [security policy](../security/policy)
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation within the code base (if appropriate)
