### PR TITLE
fix: Update automigrate initContainers's secret ref

### DIFF
--- a/helm/charts/hydra/templates/deployment.yaml
+++ b/helm/charts/hydra/templates/deployment.yaml
@@ -51,7 +51,7 @@ spec:
             - name: DSN
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "hydra.fullname" . }}
+                  name: {{ include "hydra.secretname" . }}
                   key: dsn
     {{- end}}
       volumes:


### PR DESCRIPTION
DSN value derived for automigrate initContainers doesn't account for existingSecret value.

## Related issue

#160 160

## Proposed changes

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
- [x] I have read the [security policy](../security/policy)
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation within the code base (if appropriate)
