### PR TITLE
chore: update oathkeeper-maester version

### DIFF
--- a/helm/charts/oathkeeper-maester/values.yaml
+++ b/helm/charts/oathkeeper-maester/values.yaml
@@ -17,7 +17,7 @@ image:
   # ORY Oathkeeper Rule Controller image
   repository: oryd/oathkeeper-maester
   # ORY Oathkeeper Rule Controller version
-  tag: "v0.0.9"
+  tag: "v0.1.0"
   # Image pull policy
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
0.0.9 -> 0.1.0