### PR TITLE
feat(hydra): extra volumes

### DIFF
--- a/helm/charts/hydra/templates/deployment.yaml
+++ b/helm/charts/hydra/templates/deployment.yaml
@@ -47,6 +47,9 @@ spec:
             - name: {{ include "hydra.name" . }}-config-volume
               mountPath: /etc/config
               readOnly: true
+            {{- if .Values.deployment.extraVolumeMounts }}
+{{ toYaml .Values.deployment.extraVolumeMounts | indent 12 }}
+            {{- end }}
           env:
             - name: DSN
               valueFrom:
@@ -58,6 +61,10 @@ spec:
         - name: {{ include "hydra.name" . }}-config-volume
           configMap:
             name: {{ include "hydra.fullname" . }}
+        {{- if .Values.deployment.extraVolumes }}
+{{ toYaml .Values.deployment.extraVolumes | indent 8 }}
+        {{- end }}
+
       {{- if .Values.deployment.serviceAccountName  }}
       serviceAccountName: {{ .Values.deployment.serviceAccountName }}
       {{- end }}
@@ -70,6 +77,9 @@ spec:
             - name: {{ include "hydra.name" . }}-config-volume
               mountPath: /etc/config
               readOnly: true
+            {{- if .Values.deployment.extraVolumeMounts }}
+{{ toYaml .Values.deployment.extraVolumeMounts | indent 12 }}
+            {{- end }}
           args: [
             "serve",
             "all",

--- a/helm/charts/hydra/values.yaml
+++ b/helm/charts/hydra/values.yaml
@@ -142,6 +142,20 @@ deployment:
   ## Uncoment if it is needed to provide a ServiceAccount for the Hydra deployment.
   # serviceAccountName:
 
+  extraVolumes: []
+  extraVolumeMounts: []
+  # If yout want to mount external volume
+  # For example, mount a secret containing Certificate root CA to verify database
+  # TLS connection.
+  # extraVolumes:
+  #   - name: postgresql-tls
+  #     secret:
+  #       secretName: postgresql-root-ca
+  # extraVolumeMounts:
+  #   - name: postgresql-tls
+  #     mountPath: "/etc/postgresql-tls"
+  #     readOnly: true
+
 # Configure node affinity
 affinity: {}
 


### PR DESCRIPTION
## Related issue

We are using hydra with a PostgreSQL database using TLS for remote connections.
In order to enforce security we want to use PostgreSQL `verify-full` or `verify-ca` sslmode which triggers server certificate validation against root CA
We need to mount the root CA certificate on the hydra pods to use this file in Postgres' DSN ( `sslrootcert` parameter)

## Proposed changes

Add helm values to authorize extra volumes to be mounted in hydra pods.

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
- [x] I have read the [security policy](../security/policy)
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation within the code base (if appropriate)

