### PR TITLE
feat: make secret-creation customizable in kratos

### DIFF
--- a/docs/helm/kratos.md
+++ b/docs/helm/kratos.md
@@ -57,7 +57,7 @@ Additionally, the following extra settings are available:
 
 - `kratos.autoMigrate` (bool): If enabled, an `initContainer` running `kratos migrate sql` will be created.
 - `kratos.development` (bool): If enabled, kratos will run with `--dev` argument.
-- `secret.enabled` (bool): If false, a secret is not created (contains `dsn`, `secretsCookie` and `secretsDefault`)
+- `secret.enabled` (bool): If `true` (default), a Kubernetes Secret is created (contains `dsn`, `secretsCookie` and `secretsDefault`). Also generates `secertsCookie` and `secretsDefault` unless already set.
 - `secret.nameOverride` (string): Let's you override the name of the secret to be used
 - `ingress.admin.enabled` (bool): If enabled, an ingress is created on admin endpoint
 - `ingress.public.enabled` (bool): If enabled, an ingress is created on public endpoint

--- a/docs/helm/kratos.md
+++ b/docs/helm/kratos.md
@@ -57,5 +57,9 @@ Additionally, the following extra settings are available:
 
 - `kratos.autoMigrate` (bool): If enabled, an `initContainer` running `kratos migrate sql` will be created.
 - `kratos.development` (bool): If enabled, kratos will run with `--dev` argument.
+- `secret.enabled` (bool): If false, a secret is not created (contains `dsn`, `secretsCookie` and `secretsDefault`)
+- `secret.nameOverride` (string): Let's you override the name of the secret to be used
 - `ingress.admin.enabled` (bool): If enabled, an ingress is created on admin endpoint
 - `ingress.public.enabled` (bool): If enabled, an ingress is created on public endpoint
+
+Check values.yaml for more configuration options.

--- a/helm/charts/kratos/templates/_helpers.tpl
+++ b/helm/charts/kratos/templates/_helpers.tpl
@@ -25,6 +25,17 @@ If release name contains chart name it will be used as a full name.
 {{- end -}}
 
 {{/*
+Create a secret name which can be overridden.
+*/}}
+{{- define "kratos.secretname" -}}
+{{- if .Values.secret.nameOverride -}}
+{{- .Values.secret.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{ include "kratos.fullname" . }}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Create chart name and version as used by the chart label.
 */}}
 {{- define "kratos.chart" -}}

--- a/helm/charts/kratos/templates/deployment.yaml
+++ b/helm/charts/kratos/templates/deployment.yaml
@@ -54,19 +54,19 @@ spec:
               name: DSN
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "kratos.fullname" . }}
+                  name: {{ include "kratos.secretname" . }}
                   key: dsn
             -
               name: SECRETS_DEFAULT
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "kratos.fullname" . }}
+                  name: {{ include "kratos.secretname" . }}
                   key: secretsDefault
             -
               name: SECRETS_COOKIE
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "kratos.fullname" . }}
+                  name: {{ include "kratos.secretname" . }}
                   key: secretsCookie
     {{- end}}
       volumes:
@@ -98,19 +98,19 @@ spec:
               name: DSN
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "kratos.fullname" . }}
+                  name: {{ include "kratos.secretname" . }}
                   key: dsn
             -
               name: SECRETS_DEFAULT
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "kratos.fullname" . }}
+                  name: {{ include "kratos.secretname" . }}
                   key: secretsDefault
             -
               name: SECRETS_COOKIE
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "kratos.fullname" . }}
+                  name: {{ include "kratos.secretname" . }}
                   key: secretsCookie
           ports:
             - name: http-admin

--- a/helm/charts/kratos/templates/secrets.yaml
+++ b/helm/charts/kratos/templates/secrets.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.secret.enabled -}}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -11,3 +12,4 @@ data:
   # Generate a random secret if the user doesn't give one. User given secret has priority
   secretsDefault: {{ ( include "kratos.secrets.default" . | default ( randAlphaNum 32 )) | required "Value kratos.config.secrets.default can not be empty!" | b64enc | quote }}
   secretsCookie: {{ ( include "kratos.secrets.cookie" . | default ( randAlphaNum 32 )) | required "Value kratos.config.secrets.cookie can not be empty!" | b64enc | quote }}
+{{- end }}

--- a/helm/charts/kratos/values.yaml
+++ b/helm/charts/kratos/values.yaml
@@ -33,6 +33,12 @@ service:
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
 
+secret:
+  # switch to false to prevent creating the secret
+  enabled: true
+  # ... and choose a different name for a secret you provide like this
+  # nameOverride: "MyOtherName"
+
 ingress:
   admin:
     enabled: false


### PR DESCRIPTION
## Proposed changes

Secret management is often enough quite opinionated. To make it more flexible with different approaches, i's suggest to make it possible to switch-off the secret creation in kratos and be able inject ones own secret, no matter how that has been created.

## Checklist

- [X] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
- [X] I have read the [security policy](../security/policy)
- [X] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] I have added necessary documentation within the code base (if appropriate)