### PR TITLE
feat: courier.smpt.connection_uri handled secret

### DIFF
--- a/helm/charts/kratos/templates/_helpers.tpl
+++ b/helm/charts/kratos/templates/_helpers.tpl
@@ -73,6 +73,9 @@ Generate the configmap data, redacting secrets
 {{- define "kratos.configmap" -}}
 {{- $config := unset .Values.kratos.config "dsn" -}}
 {{- $config := unset $config "secrets" -}}
+{{- if .Values.kratos.config.courier.smtp.connection_uri -}}
+{{- $config = set $config "courier" (set $config.courier "smtp" (unset $config.courier.smtp "connection_uri")) -}}
+{{- end -}}
 {{- toYaml $config -}}
 {{- end -}}
 

--- a/helm/charts/kratos/templates/deployment.yaml
+++ b/helm/charts/kratos/templates/deployment.yaml
@@ -68,6 +68,14 @@ spec:
                 secretKeyRef:
                   name: {{ include "kratos.secretname" . }}
                   key: secretsCookie
+          {{- if .Values.kratos.config.courier.smtp.connection_uri }}
+            - 
+              name: COURIER_SMTP_CONNECTION_URI
+              valueFrom: 
+                secretKeyRef: 
+                  name: {{ include "kratos.secretname" . }}
+                  key: smtpConnectionURI
+          {{- end}}
     {{- end}}
       volumes:
         -
@@ -112,6 +120,14 @@ spec:
                 secretKeyRef:
                   name: {{ include "kratos.secretname" . }}
                   key: secretsCookie
+            {{- if .Values.kratos.config.courier.smtp.connection_uri }}
+            - 
+              name: COURIER_SMTP_CONNECTION_URI
+              valueFrom: 
+                secretKeyRef: 
+                  name: {{ include "kratos.secretname" . }}
+                  key: smtpConnectionURI
+          {{- end}}
           ports:
             - name: http-admin
               containerPort: {{ .Values.kratos.config.serve.admin.port }}

--- a/helm/charts/kratos/templates/secrets.yaml
+++ b/helm/charts/kratos/templates/secrets.yaml
@@ -12,4 +12,7 @@ data:
   # Generate a random secret if the user doesn't give one. User given secret has priority
   secretsDefault: {{ ( include "kratos.secrets.default" . | default ( randAlphaNum 32 )) | required "Value kratos.config.secrets.default can not be empty!" | b64enc | quote }}
   secretsCookie: {{ ( include "kratos.secrets.cookie" . | default ( randAlphaNum 32 )) | required "Value kratos.config.secrets.cookie can not be empty!" | b64enc | quote }}
+  {{- if .Values.kratos.config.courier.smtp.connection_uri }}
+  smtpConnectionURI: {{ .Values.kratos.config.courier.smtp.connection_uri | b64enc | quote }}
+  {{- end }}
 {{- end }}

--- a/helm/charts/kratos/values.yaml
+++ b/helm/charts/kratos/values.yaml
@@ -75,6 +75,9 @@ kratos:
   autoMigrate: false
 
   config:
+    courier:
+      smtp: {}
+      
     serve:
       public:
         port: 4433


### PR DESCRIPTION
If `courier.smpt.connection_uri`  is set in values, it will be put into a secret in the same way how dsn or secrets are handled so far.

## Proposed changes
Implement same handling of value as for e.g. DSN. See #174.

## Checklist
- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
- [x] I have read the [security policy](../security/policy)
- [ ] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.