### PR TITLE
feat: Add support for priorityClassName for Helm charts

### DIFF
--- a/helm/charts/hydra-maester/Chart.yaml
+++ b/helm/charts/hydra-maester/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 appVersion: "0.0.5-alpha10"
 description: A Helm chart for Kubernetes
 name: hydra-maester
-version: 0.0.5-alpha10
+version: 0.0.6-alpha10
 type: application

--- a/helm/charts/hydra-maester/templates/deployment.yaml
+++ b/helm/charts/hydra-maester/templates/deployment.yaml
@@ -42,6 +42,9 @@ spec:
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
       serviceAccountName: {{ include "hydra-maester.name" . }}-account
+      {{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName }}
+      {{- end }}
       nodeSelector:
       {{- with .Values.deployment.nodeSelector }}
         {{- toYaml . | nindent 8 }}

--- a/helm/charts/hydra-maester/values.yaml
+++ b/helm/charts/hydra-maester/values.yaml
@@ -14,6 +14,10 @@ image:
   # Image pull policy
   pullPolicy: IfNotPresent
 
+## Pod priority
+## https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/
+# priorityClassName: ""
+
 adminService:
   name:
   port:

--- a/helm/charts/hydra/Chart.yaml
+++ b/helm/charts/hydra/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "v1.7.4"
 description: A Helm chart for deploying ORY Hydra in Kubernetes
 name: hydra
-version: 0.0.1
+version: 0.1.0
 keywords:
   - oauth2
   - openid-connect

--- a/helm/charts/hydra/templates/deployment.yaml
+++ b/helm/charts/hydra/templates/deployment.yaml
@@ -137,6 +137,9 @@ spec:
                   key: secretsCookie
           resources:
             {{- toYaml .Values.deployment.resources | nindent 12 }}
+      {{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName }}
+      {{- end }}
       {{- with .Values.deployment.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/helm/charts/hydra/values.yaml
+++ b/helm/charts/hydra/values.yaml
@@ -16,6 +16,10 @@ nameOverride: ""
 # Full chart name override
 fullnameOverride: ""
 
+## Pod priority
+## https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/
+# priorityClassName: ""
+
 # Configures the Kubernetes service
 service:
   # Configures the Kubernetes service for the proxy port.


### PR DESCRIPTION
## Proposed changes

The helm charts did not have the option to specify a priority class. In large Kubernetes clusters with some type of workloads, priorityClass gives more context to the scheduler about which pod to evict first.

[Official documentation](https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/)

## Checklist

- [X] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
- [X] I have read the [security policy](../security/policy)
- [X] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.

## Further comments

Not sure about Helm chart versioning, on Helm stable that would have been a minor (feature addition) but I am not sure this is relevant here. I'll edit the PR if needed.