### PR TITLE
fix: deployment.yaml of hydra chart

### DIFF
--- a/helm/charts/hydra/Chart.yaml
+++ b/helm/charts/hydra/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "v1.7.4"
 description: A Helm chart for deploying ORY Hydra in Kubernetes
 name: hydra
-version: 0.1.0
+version: 0.1.1
 keywords:
   - oauth2
   - openid-connect

--- a/helm/charts/hydra/templates/deployment.yaml
+++ b/helm/charts/hydra/templates/deployment.yaml
@@ -146,9 +146,9 @@ spec:
       {{- end }}
       {{- with .Values.deployment.tolerations }}
       tolerations:
-      {{- toYaml . | nindent 8 }}
-    {{- end }}
-    {{- with .Values.affinity }}
-    affinity:
-      {{- toYaml . | nindent 8 }}
-    {{- end }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}


### PR DESCRIPTION
## What happens?
The Affinity option in the Hydra Chart is currently unavailable.
```
Error: Failed to render chart: exit status 1: Error: unable to build kubernetes objects from release manifest: error validating "": error validating data: ValidationError(Deployment.spec.template): unknown field "affinity" in io.k8s.api.core.v1.PodTemplateSpec
```
## Proposed changes
Move the affinity to the appropriate location in deployment.yaml.

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
- [x] I have read the [security policy](../security/policy)
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation within the code base (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
