### PR TITLE
feat(kratos): Add support for specifying env vars from a secret

### DIFF
--- a/docs/helm/kratos.md
+++ b/docs/helm/kratos.md
@@ -57,9 +57,10 @@ Additionally, the following extra settings are available:
 
 - `kratos.autoMigrate` (bool): If enabled, an `initContainer` running `kratos migrate sql` will be created.
 - `kratos.development` (bool): If enabled, kratos will run with `--dev` argument.
-- `secret.enabled` (bool): If `true` (default), a Kubernetes Secret is created (contains `dsn`, `secretsCookie` and `secretsDefault`). Also generates `secertsCookie` and `secretsDefault` unless already set.
-- `secret.nameOverride` (string): Let's you override the name of the secret to be used
+- `secret.enabled` (bool): If `true` (default), a Kubernetes Secret is created (contains `dsn`, `secretsCookie` and `secretsDefault`). Also generates `secretsCookie` and `secretsDefault` unless already set.
+- `secret.nameOverride` (string): Lets you override the name of the secret to be used
 - `ingress.admin.enabled` (bool): If enabled, an ingress is created on admin endpoint
 - `ingress.public.enabled` (bool): If enabled, an ingress is created on public endpoint
+- `deployment.environmentSecretsName` (string): Allows you to set arbitrary environment variables from [a secret containing a list of keys and values](https://kubernetes.io/docs/tasks/inject-data-application/distribute-credentials-secure/#configure-all-key-value-pairs-in-a-secret-as-container-environment-variables). (This secret is not created by the Helm chart)
 
 Check values.yaml for more configuration options.

--- a/helm/charts/kratos/templates/deployment.yaml
+++ b/helm/charts/kratos/templates/deployment.yaml
@@ -69,13 +69,18 @@ spec:
                   name: {{ include "kratos.secretname" . }}
                   key: secretsCookie
           {{- if .Values.kratos.config.courier.smtp.connection_uri }}
-            - 
+            -
               name: COURIER_SMTP_CONNECTION_URI
-              valueFrom: 
-                secretKeyRef: 
+              valueFrom:
+                secretKeyRef:
                   name: {{ include "kratos.secretname" . }}
                   key: smtpConnectionURI
           {{- end}}
+        {{- if .Values.deployment.environmentSecretsName }}
+          envFrom:
+          - secretRef:
+              name: {{ .Values.deployment.environmentSecretsName }}
+        {{- end}}
     {{- end}}
       volumes:
         -
@@ -121,13 +126,18 @@ spec:
                   name: {{ include "kratos.secretname" . }}
                   key: secretsCookie
             {{- if .Values.kratos.config.courier.smtp.connection_uri }}
-            - 
+            -
               name: COURIER_SMTP_CONNECTION_URI
-              valueFrom: 
-                secretKeyRef: 
+              valueFrom:
+                secretKeyRef:
                   name: {{ include "kratos.secretname" . }}
                   key: smtpConnectionURI
           {{- end}}
+        {{- if .Values.deployment.environmentSecretsName }}
+          envFrom:
+          - secretRef:
+              name: {{ .Values.deployment.environmentSecretsName }}
+        {{- end}}
           ports:
             - name: http-admin
               containerPort: {{ .Values.kratos.config.serve.admin.port }}

--- a/helm/charts/kratos/values.yaml
+++ b/helm/charts/kratos/values.yaml
@@ -88,7 +88,7 @@ kratos:
   config:
     courier:
       smtp: {}
-      
+
     serve:
       public:
         port: 4433
@@ -129,6 +129,12 @@ deployment:
   #      lines, adjust them as necessary, and remove the curly braces after 'annotations:'.
   #      e.g.  sidecar.istio.io/rewriteAppHTTPProbers: "true"
 
+  # The secret specified here will be used to load environment variables with envFrom.
+  # This allows arbitrary environment variables to be provided to the application which is useful for
+  # sensitive values which should not be in a configMap.
+  # This secret is not created by the helm chart and must already exist in the namespace.
+  # https://kubernetes.io/docs/tasks/inject-data-application/distribute-credentials-secure/#configure-all-key-value-pairs-in-a-secret-as-container-environment-variables
+  environmentSecretsName:
 
 # Configure node affinity
 affinity: {}


### PR DESCRIPTION
## Related issue

Related to a discussion in Slack and loosely to this change: https://github.com/ory/x/commit/5b71f1e15fa3264e931d74e58965af73a51c8fc5

## Proposed changes

When setting up Kratos via Helm there are currently secrets in the config that should be passed in via another means.
The case I'm dealing with specifically is `kratos.config.selfservice.methods.oidc.config.providers`, which contains `client_id` and `client_secret` for each provider.
In this case my ideal scenario seems to be to set up secret containing the provider config, and then have that create env vars which Kratos can use to override config (in this case: `SELFSERVICE_METHODS_OIDC`.)
This requires that the secret is created separately, but I think that is beneficial. If it were up to Helm to create the secret then anyone who needed to run the chart would also have to have the contents of the secret. And in my case I'm executing Helm with Terraform, which would require the secrets to go into the Terraform state, and be accessible by anyone who needs to run that TF.


## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md) and signed the CLA.
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added necessary documentation within the code base (if appropriate).

## Further comments
