### PR TITLE
Fix maester chart naming clashes between hydra & oathkeeper

### DIFF
--- a/helm/charts/hydra/Chart.yaml
+++ b/helm/charts/hydra/Chart.yaml
@@ -24,5 +24,5 @@ dependencies:
   - name: hydra-maester
     version: 0.4.11
     condition: maester.enabled
-    alias: maester
+    alias: hydra-maester
     repository: file://../hydra-maester

--- a/helm/charts/oathkeeper/Chart.yaml
+++ b/helm/charts/oathkeeper/Chart.yaml
@@ -25,5 +25,5 @@ dependencies:
   - name: oathkeeper-maester
     version: 0.4.11
     condition: maester.enabled
-    alias: maester
+    alias: oathkeeper-maester
     repository: file://../oathkeeper-maester


### PR DESCRIPTION
## Related issue
#138 

@aeneasr this should be pretty easy to solve.
