### PR TITLE
feat(hydra): make hydra chart secret annotations configurable

### DIFF
--- a/docs/helm/hydra.md
+++ b/docs/helm/hydra.md
@@ -45,6 +45,15 @@ Alternatively, you can use an existing
 [Kubernetes Secret](https://kubernetes.io/docs/concepts/configuration/secret/)
 instead of letting the Helm Chart create one for you:
 
+Last but not least, if you'd like to customise the way secrets are updated on your kubernetes cluster, you can do so via the `hydra.config.secretAnnotations` value as follows:
+
+```bash
+$ helm install \
+    --set hydra.config.secretAnnotations."helm\.sh/hook"="pre-install\,pre-upgrade" \
+    --set hydra.config.secretAnnotations."helm\.sh/hook-delete-policy"=before-hook-creation \
+    ory/hydra
+```
+
 ```bash
 
 $ kubectl create secret generic my-secure-secret --from-literal=dsn=postgres://foo:bar@baz:1234/db \

--- a/helm/charts/hydra/Chart.yaml
+++ b/helm/charts/hydra/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "v1.8.5"
 description: A Helm chart for deploying ORY Hydra in Kubernetes
 name: hydra
-version: 0.4.13
+version: 0.4.14
 keywords:
   - oauth2
   - openid-connect

--- a/helm/charts/hydra/templates/_helpers.tpl
+++ b/helm/charts/hydra/templates/_helpers.tpl
@@ -105,6 +105,7 @@ Generate the configmap data, redacting secrets
 {{- define "hydra.configmap" -}}
 {{- $config := unset .Values.hydra.config "dsn" -}}
 {{- $config := unset $config "secrets" -}}
+{{- $config := unset $config "secretAnnotations" -}}
 {{- toYaml $config -}}
 {{- end -}}
 

--- a/helm/charts/hydra/templates/secrets.yaml
+++ b/helm/charts/hydra/templates/secrets.yaml
@@ -7,9 +7,9 @@ metadata:
   labels:
 {{ include "hydra.labels" . | indent 4 }}
   annotations:
-    # Create the secret before installation, and only then. This saves the secret from regenerating during an upgrade
-    "helm.sh/hook": "pre-install"
-    "helm.sh/hook-delete-policy": "before-hook-creation"
+    {{- with .Values.hydra.config.secretAnnotations }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
 type: Opaque
 data:
   # Generate a random secret if the user doesn't give one. User given password has priority

--- a/helm/charts/hydra/values.yaml
+++ b/helm/charts/hydra/values.yaml
@@ -99,6 +99,10 @@ hydra:
           - 172.16.0.0/12
           - 192.168.0.0/16
     secrets: {}
+    secretAnnotations:
+    # Create the secret before installation, and only then. This saves the secret from regenerating during an upgrade
+      helm.sh/hook: "pre-install,pre-upgrade"
+      helm.sh/hook-delete-policy: "before-hook-creation"
     # Use a pre-existing secret (see secret.yaml for required fields)
     # existingSecret: my-preexisting-secret
     urls:

--- a/helm/charts/hydra/values.yaml
+++ b/helm/charts/hydra/values.yaml
@@ -101,7 +101,7 @@ hydra:
     secrets: {}
     secretAnnotations:
     # Create the secret before installation, and only then. This saves the secret from regenerating during an upgrade
-      helm.sh/hook: "pre-install,pre-upgrade"
+      helm.sh/hook: "pre-install"
       helm.sh/hook-delete-policy: "before-hook-creation"
     # Use a pre-existing secret (see secret.yaml for required fields)
     # existingSecret: my-preexisting-secret


### PR DESCRIPTION
## Related issue

#TBD

@k9ert

## Proposed changes

This PR allows the user of the chart to customize the Secrets' annotations so to better control the  object lifecycle in their Kubernetes cluster.
The use case I propose is a change of database host/cluster, which now would require getting around the chart or providing external secret or reinstalling the chart: with this change a user can allow the secret to be updated during helm upgrades with minimal distruption (such as deleting and reinstalling the chart) or external actions (such as manually modifying the secrets or providing one outside of the chart)

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
      and signed the CLA.
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [x] I have added necessary documentation within the code base (if
      appropriate).

## Further comments

- ~CLA signing doesn't working at the time of writing~
- I didn't open an issue yet, I can do that if the PR reaches some consensus
- I tested the chart locally on minikube
