### PR TITLE
feat(hydra): add support for custom env vars

### DIFF
--- a/helm/charts/hydra/templates/deployment.yaml
+++ b/helm/charts/hydra/templates/deployment.yaml
@@ -56,6 +56,9 @@ spec:
                 secretKeyRef:
                   name: {{ include "hydra.secretname" . }}
                   key: dsn
+            {{- if .Values.hydra.env }}
+            {{- toYaml .Values.hydra.env | nindent 12 }}      
+            {{- end }}
     {{- end}}
       volumes:
         - name: {{ include "hydra.name" . }}-config-volume
@@ -135,6 +138,9 @@ spec:
                 secretKeyRef:
                   name: {{ include "hydra.secretname" . }}
                   key: secretsCookie
+            {{- if .Values.hydra.env }}
+            {{- toYaml .Values.hydra.env | nindent 12 }}      
+            {{- end }}
           resources:
             {{- toYaml .Values.deployment.resources | nindent 12 }}
       {{- if .Values.priorityClassName }}

--- a/helm/charts/hydra/values.yaml
+++ b/helm/charts/hydra/values.yaml
@@ -104,6 +104,20 @@ hydra:
     urls:
       self: {}
 
+  # If you want to use Jaeger with agents being deployed in a daemonset, you can 
+  # use the following ENV vars to configure the right endpoints using the IP 
+  # address of the node the pod has been deployed to. 
+  #
+  # env:
+  #   - name: JAEGER_AGENT_HOST
+  #     valueFrom:
+  #       fieldRef:
+  #         fieldPath: status.hostIP 
+  #   - name: TRACING_PROVIDERS_JAEGER_LOCAL_AGENT_ADDRESS
+  #     value: $(JAEGER_AGENT_HOST):6831
+  #   - name: TRACING_PROVIDERS_JAEGER_SAMPLING_SERVER_URL
+  #     value: http://$(JAEGER_AGENT_HOST):5778
+
   autoMigrate: false
   dangerousForceHttp: false
   dangerousAllowInsecureRedirectUrls: false


### PR DESCRIPTION
## Related issue
See #210  for details.

## Proposed changes
Change the template for deployments to pick up any values defined under `hydra.env` and render them in deployment.yaml as additional env entries. 

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
      and signed the CLA.
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [x] I have added necessary documentation within the code base (if
      appropriate).

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
