### PR TITLE
feat(helm): add extra environment variables and datadog tracing to charts

### DIFF
--- a/helm/charts/hydra/templates/deployment.yaml
+++ b/helm/charts/hydra/templates/deployment.yaml
@@ -56,8 +56,8 @@ spec:
                 secretKeyRef:
                   name: {{ include "hydra.secretname" . }}
                   key: dsn
-            {{- if .Values.hydra.env }}
-            {{- toYaml .Values.hydra.env | nindent 12 }}      
+            {{- with .Values.deployment.extraEnv }}
+              {{- toYaml . | nindent 12 }}
             {{- end }}
     {{- end}}
       volumes:

--- a/helm/charts/hydra/templates/deployment.yaml
+++ b/helm/charts/hydra/templates/deployment.yaml
@@ -118,6 +118,22 @@ spec:
             periodSeconds: 10
             failureThreshold: 5
           env:
+            {{- if .Values.deployment.tracing.datadog.enabled }}
+            - name: TRACING_PROVIDER
+              value: datadog
+            - name: DD_ENV
+              value: {{ .Values.deployment.tracing.datadog.env | default "none" | quote }}
+            - name: DD_VERSION
+              value: {{ .Values.deployment.tracing.datadog.version | default .Values.image.tag | quote }}
+            - name: DD_SERVICE
+              value: {{ .Values.deployment.tracing.datadog.service | default "ory/hydra" | quote }}
+            {{- if .Values.deployment.tracing.datadog.useHostIP }}
+            - name: DD_AGENT_HOST
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+            {{- end }}
+            {{- end }}
             {{- $issuer := include "hydra.config.urls.issuer" . -}}
             {{- if $issuer }}
             - name: URLS_SELF_ISSUER
@@ -138,8 +154,8 @@ spec:
                 secretKeyRef:
                   name: {{ include "hydra.secretname" . }}
                   key: secretsCookie
-            {{- if .Values.hydra.env }}
-            {{- toYaml .Values.hydra.env | nindent 12 }}      
+            {{- with .Values.deployment.extraEnv }}
+              {{- toYaml . | nindent 12 }}
             {{- end }}
           resources:
             {{- toYaml .Values.deployment.resources | nindent 12 }}

--- a/helm/charts/hydra/values.yaml
+++ b/helm/charts/hydra/values.yaml
@@ -5,7 +5,7 @@ image:
   # ORY Hydra image
   repository: oryd/hydra
   # ORY Hydra version
-  tag: v1.4.6
+  tag: v1.8.5
   # Image pull policy
   pullPolicy: IfNotPresent
 
@@ -154,6 +154,32 @@ deployment:
   # If you do want to specify node labels, uncomment the following
   # lines, adjust them as necessary, and remove the curly braces after 'nodeSelector:'.
   #   foo: bar
+
+  extraEnv: []
+
+  # Configuration for tracing providers. Only datadog is currently supported through this block.
+  # If you need to use a different tracing provider, please manually set the configuration values
+  # via "hydra.config" or via "deployment.extraEnv".
+  tracing:
+    datadog:
+      enabled: false
+
+      # Sets the datadog DD_ENV environment variable. This value indicates the environment where hydra is running.
+      # Default value: "none".
+      # env: production
+
+      # Sets the datadog DD_VERSION environment variable. This value indicates the version that hydra is running.
+      # Default value: .Values.image.tag (i.e. the tag used for the docker image).
+      # version: X.Y.Z
+
+      # Sets the datadog DD_SERVICE environment variable. This value indicates the name of the service running.
+      # Default value: "ory/hydra".
+      # service: ory/hydra
+
+      # Sets the datadog DD_AGENT_HOST environment variable. This value indicates the host address of the datadog agent.
+      # If set to true, this configuration will automatically set DD_AGENT_HOST to the field "status.hostIP" of the pod.
+      # Default value: false.
+      # useHostIP: true
 
   # Configure node tolerations.
   tolerations: []

--- a/helm/charts/hydra/values.yaml
+++ b/helm/charts/hydra/values.yaml
@@ -108,20 +108,6 @@ hydra:
     urls:
       self: {}
 
-  # If you want to use Jaeger with agents being deployed in a daemonset, you can 
-  # use the following ENV vars to configure the right endpoints using the IP 
-  # address of the node the pod has been deployed to. 
-  #
-  # env:
-  #   - name: JAEGER_AGENT_HOST
-  #     valueFrom:
-  #       fieldRef:
-  #         fieldPath: status.hostIP 
-  #   - name: TRACING_PROVIDERS_JAEGER_LOCAL_AGENT_ADDRESS
-  #     value: $(JAEGER_AGENT_HOST):6831
-  #   - name: TRACING_PROVIDERS_JAEGER_SAMPLING_SERVER_URL
-  #     value: http://$(JAEGER_AGENT_HOST):5778
-
   autoMigrate: false
   dangerousForceHttp: false
   dangerousAllowInsecureRedirectUrls: false
@@ -155,6 +141,19 @@ deployment:
   # lines, adjust them as necessary, and remove the curly braces after 'nodeSelector:'.
   #   foo: bar
 
+  # If you want to use Jaeger with agents being deployed in a daemonset, you can 
+  # use the following ENV vars to configure the right endpoints using the IP 
+  # address of the node the pod has been deployed to. 
+  #
+  # extraEnv:
+  #   - name: JAEGER_AGENT_HOST
+  #     valueFrom:
+  #       fieldRef:
+  #         fieldPath: status.hostIP 
+  #   - name: TRACING_PROVIDERS_JAEGER_LOCAL_AGENT_ADDRESS
+  #     value: $(JAEGER_AGENT_HOST):6831
+  #   - name: TRACING_PROVIDERS_JAEGER_SAMPLING_SERVER_URL
+  #     value: http://$(JAEGER_AGENT_HOST):5778
   extraEnv: []
 
   # Configuration for tracing providers. Only datadog is currently supported through this block.

--- a/helm/charts/kratos/templates/deployment.yaml
+++ b/helm/charts/kratos/templates/deployment.yaml
@@ -50,6 +50,27 @@ spec:
               mountPath: /etc/config
               readOnly: true
           env:
+            {{- if .Values.deployment.tracing.datadog.enabled }}
+            -
+              name: TRACING_PROVIDER
+              value: datadog
+            -
+              name: DD_ENV
+              value: {{ .Values.deployment.tracing.datadog.env | default "none" | quote }}
+            -
+              name: DD_VERSION
+              value: {{ .Values.deployment.tracing.datadog.version | default .Values.image.tag | quote }}
+            -
+              name: DD_SERVICE
+              value: {{ .Values.deployment.tracing.datadog.service | default "ory/kratos" | quote }}
+            {{- if .Values.deployment.tracing.datadog.useHostIP }}
+            -
+              name: DD_AGENT_HOST
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+            {{- end }}
+            {{- end }}
             -
               name: DSN
               valueFrom:
@@ -76,6 +97,9 @@ spec:
                   name: {{ include "kratos.secretname" . }}
                   key: smtpConnectionURI
           {{- end}}
+            {{- with .Values.deployment.extraEnv }}
+              {{- toYaml . | nindent 12 }}
+            {{- end }}
         {{- if .Values.deployment.environmentSecretsName }}
           envFrom:
           - secretRef:

--- a/helm/charts/kratos/values.yaml
+++ b/helm/charts/kratos/values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: oryd/kratos
-  tag: v0.5.2-alpha.1-sqlite
+  tag: v0.5.5-alpha.1-sqlite
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []
@@ -115,6 +115,32 @@ deployment:
   # If you do want to specify node labels, uncomment the following
   # lines, adjust them as necessary, and remove the curly braces after 'annotations:'.
   #   foo: bar
+
+  extraEnv: []
+
+  # Configuration for tracing providers. Only datadog is currently supported through this block.
+  # If you need to use a different tracing provider, please manually set the configuration values
+  # via "kratos.config" or via "deployment.extraEnv".
+  tracing:
+    datadog:
+      enabled: false
+
+      # Sets the datadog DD_ENV environment variable. This value indicates the environment where kratos is running.
+      # Default value: "none".
+      # env: production
+
+      # Sets the datadog DD_VERSION environment variable. This value indicates the version that kratos is running.
+      # Default value: .Values.image.tag (i.e. the tag used for the docker image).
+      # version: X.Y.Z
+
+      # Sets the datadog DD_SERVICE environment variable. This value indicates the name of the service running.
+      # Default value: "ory/kratos".
+      # service: ory/kratos
+
+      # Sets the datadog DD_AGENT_HOST environment variable. This value indicates the host address of the datadog agent.
+      # If set to true, this configuration will automatically set DD_AGENT_HOST to the field "status.hostIP" of the pod.
+      # Default value: false.
+      # useHostIP: true
 
   # Configure node tolerations.
   tolerations: []

--- a/helm/charts/oathkeeper/templates/deployment-controller.yaml
+++ b/helm/charts/oathkeeper/templates/deployment-controller.yaml
@@ -62,6 +62,25 @@ spec:
             - name: MUTATORS_ID_TOKEN_CONFIG_JWKS_URL
               value: "file:///etc/secrets/mutator.id_token.jwks.json"
             {{- end }}
+            {{- if .Values.deployment.tracing.datadog.enabled }}
+            - name: TRACING_PROVIDER
+              value: datadog
+            - name: DD_ENV
+              value: {{ .Values.deployment.tracing.datadog.env | default "none" | quote }}
+            - name: DD_VERSION
+              value: {{ .Values.deployment.tracing.datadog.version | default .Values.image.tag | quote }}
+            - name: DD_SERVICE
+              value: {{ .Values.deployment.tracing.datadog.service | default "ory/oathkeeper" | quote }}
+            {{- if .Values.deployment.tracing.datadog.useHostIP }}
+            - name: DD_AGENT_HOST
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+            {{- end }}
+            {{- end }}
+            {{- with .Values.deployment.extraEnv }}
+              {{- toYaml . | nindent 12 }}
+            {{- end }}
           volumeMounts:
             - name: {{ include "oathkeeper.name" . }}-config-volume
               mountPath: /etc/config

--- a/helm/charts/oathkeeper/values.yaml
+++ b/helm/charts/oathkeeper/values.yaml
@@ -13,7 +13,7 @@ image:
   # ORY Oathkeeper image
   repository: oryd/oathkeeper
   # ORY Oathkeeper version
-  tag: v0.38.4-beta.1
+  tag: v0.38.5
   # Image pull policy
   pullPolicy: IfNotPresent
 
@@ -134,6 +134,32 @@ deployment:
   # If you do want to specify node labels, uncomment the following
   # lines, adjust them as necessary, and remove the curly braces after 'annotations:'.
   #   foo: bar
+
+  extraEnv: []
+
+  # Configuration for tracing providers. Only datadog is currently supported through this block.
+  # If you need to use a different tracing provider, please manually set the configuration values
+  # via "oathkeeper.config" or via "deployment.extraEnv".
+  tracing:
+    datadog:
+      enabled: false
+
+      # Sets the datadog DD_ENV environment variable. This value indicates the environment where oathkeeper is running.
+      # Default value: "none".
+      # env: production
+
+      # Sets the datadog DD_VERSION environment variable. This value indicates the version that oathkeeper is running.
+      # Default value: .Values.image.tag (i.e. the tag used for the docker image).
+      # version: X.Y.Z
+
+      # Sets the datadog DD_SERVICE environment variable. This value indicates the name of the service running.
+      # Default value: "ory/oathkeeper".
+      # service: ory/oathkeeper
+
+      # Sets the datadog DD_AGENT_HOST environment variable. This value indicates the host address of the datadog agent.
+      # If set to true, this configuration will automatically set DD_AGENT_HOST to the field "status.hostIP" of the pod.
+      # Default value: false.
+      # useHostIP: true
 
   # Configure node tolerations.
   tolerations: []


### PR DESCRIPTION
## Related issue

https://github.com/ory/k8s/pull/211

## Proposed changes

This PR introduces extra environment variables and pre-defined datadog configuration for all charts.


## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
      and signed the CLA.
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature
      works.
- [x] I have added necessary documentation within the code base (if
      appropriate).

## Further comments

This PR is similar to https://github.com/ory/k8s/pull/211 but applies to all charts and is standardized across all of them.

This PR introduces the mentioned features in the same way as https://github.com/ory/k8s/pull/209.
This PR has already been tested in our staging environment.
