### PR TITLE
feat(hydra-maester): make hydra-maester pods labels customizable

### DIFF
--- a/docs/helm/hydra-maester.md
+++ b/docs/helm/hydra-maester.md
@@ -9,6 +9,8 @@ Hydra Maester is a part of the Hydra chart and is installed together with it.
 ## Configuration
 
 - `enabledNamespaces` defines the namespaces in which instances of `oauth2clients.hydra.ory.sh/v1alpha1` CR can be created. By default, users are allowed to create CR instances only in the controller's native namespace.
+- `deployment.podLabels` permit to set custom additional labels on hydra-maester controller pod.
+- `job.podLabels` permit to set custom additional labels on hydra-maester job init-crd pod (which setup crd on cluster).
 
 You can set the values in the `values.yaml` file or using the `--set` syntax of Helm during chart installation.
 

--- a/helm/charts/hydra-maester/Chart.yaml
+++ b/helm/charts/hydra-maester/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 appVersion: "v0.0.19"
 description: A Helm chart for Kubernetes
 name: hydra-maester
-version: 0.5.0
+version: 0.5.1
 type: application

--- a/helm/charts/hydra-maester/templates/crd-job.yaml
+++ b/helm/charts/hydra-maester/templates/crd-job.yaml
@@ -11,6 +11,10 @@ metadata:
 spec:
   template:
     metadata:
+      {{- with .Values.job.podLabels }}
+      labels:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       annotations:
         sidecar.istio.io/inject: "false"
     spec:

--- a/helm/charts/hydra-maester/templates/deployment.yaml
+++ b/helm/charts/hydra-maester/templates/deployment.yaml
@@ -19,6 +19,9 @@ spec:
         control-plane: controller-manager
         app.kubernetes.io/name: {{ include "hydra-maester.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
+        {{- with .Values.deployment.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       {{- with .Values.annotations }}
       annotations:
         {{- toYaml . | nindent 8 }}

--- a/helm/charts/hydra-maester/values.yaml
+++ b/helm/charts/hydra-maester/values.yaml
@@ -46,6 +46,10 @@ deployment:
   # Configure node tolerations.
   tolerations: []
   annotations: {}
+  podLabels: {}
+
+job:
+  podLabels: {}
 
 # Configure node affinity
 affinity: {}


### PR DESCRIPTION
## Related issue

none

## Proposed changes

This PR allows the user of the chart to customize the labels of hydra-maester pod and job crd-init. This feature permit us to match global network policies which allow kubernetes api access, which is not available by default.

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
      and signed the CLA.
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [x] I have added necessary documentation within the code base (if
      appropriate).

## Further comments
- CLA form respond with 404 error
- I didn't open an issue about this and don't find an existing. I choose to purpose feature insteed of issue.
- I use this chart on an "on premise" k8s cluster and hope merge it to community version.