### PR TITLE
feat: Add possibility to configure email template overrides

### DIFF
--- a/helm/charts/kratos/templates/configmap-templates.yaml
+++ b/helm/charts/kratos/templates/configmap-templates.yaml
@@ -1,0 +1,22 @@
+{{- $root := . -}}
+{{- range $method, $methodEntry := .Values.kratos.emailTemplates }}
+{{- range $result, $resultEntry := $methodEntry }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "kratos.fullname" $root }}-template-{{ $method }}-{{ $result }}
+  namespace: {{ $root.Release.Namespace }}
+  labels:
+{{ include "kratos.labels" $root | indent 4 }}
+data:
+  {{- if $resultEntry.subject }}
+  "email.subject.gotmpl": |
+    {{ $resultEntry.subject | quote }}
+  {{- end }}
+  {{- if $resultEntry.body }}
+  "email.body.gotmpl": |-
+{{ $resultEntry.body | indent 4 }}
+  {{- end }}
+{{- end }}
+{{- end }}

--- a/helm/charts/kratos/templates/deployment.yaml
+++ b/helm/charts/kratos/templates/deployment.yaml
@@ -111,6 +111,14 @@ spec:
           name: {{ include "kratos.name" . }}-config-volume
           configMap:
             name: {{ include "kratos.fullname" . }}-config
+        {{- $root := . -}}
+        {{- range $method, $methodEntry := .Values.kratos.emailTemplates }}
+        {{- range $result, $resultEntry := $methodEntry }}
+        - name: {{ include "kratos.name" $root }}-template-{{ $method }}-{{ $result }}-volume
+          configMap:
+            name: {{ include "kratos.fullname" $root }}-template-{{ $method }}-{{ $result }}
+        {{- end }}
+        {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
@@ -130,6 +138,14 @@ spec:
               name: {{ include "kratos.name" . }}-config-volume
               mountPath: /etc/config
               readOnly: true
+            {{- $root := . -}}
+            {{- range $method, $methodEntry := .Values.kratos.emailTemplates }}
+            {{- range $result, $resultEntry := $methodEntry }}
+            - name: {{ include "kratos.name" $root }}-template-{{ $method }}-{{ $result }}-volume
+              mountPath: /conf/courier-templates/{{ $method }}/{{ $result }}
+              readOnly: true
+            {{- end }}
+            {{- end }}
           env:
             -
               name: DSN

--- a/helm/charts/kratos/values.yaml
+++ b/helm/charts/kratos/values.yaml
@@ -85,9 +85,39 @@ kratos:
 #        // ...
 #      }
 
+#  You can customize the emails kratos is sending (also uncomment config.courier.template_override_path below)
+#  Note: If you are setting config.courier.template_override_path you need to supply overrides for all templates.
+#        It is currently not possible to overrides only selected methods.
+#
+#  emailTemplates:
+#    recovery:
+#      valid:
+#        subject: Recover access to your account
+#        body: |-
+#          Hi, please recover access to your account by clicking the following link:
+#
+#          <a href="{{ .RecoveryURL }}">{{ .RecoveryURL }}</a>
+#      invalid:
+#        subject: Account access attempted
+#        body: |-
+#          Hi, you (or someone else) entered this email address when trying to recover access to an account.
+#
+#          However, this email address is not on our database of registered users and therefore the attempt has failed. If this was you, check if you signed up using a different address. If this was not you, please ignore this email.
+#    verification:
+#      valid:
+#        subject: Please verify your email address
+#        body: |-
+#          Hi, please verify your account by clicking the following link:
+#
+#          <a href="{{ .RecoveryURL }}">{{ .RecoveryURL }}</a>
+#      invalid:
+#        subject:
+#        body:
+
   config:
     courier:
       smtp: {}
+      #template_override_path: /conf/courier-templates
 
     serve:
       public:


### PR DESCRIPTION
## Related issue

https://github.com/ory/k8s/issues/217

<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@aeneasr`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers either in the Github Discusssions in this repository or
join the [ORY Chat](https://www.ory.sh/chat).
-->

## Proposed changes

Currently it seems to be not possible to configure email templates in the Helm chart to customize the content of the emails kratos is sending for verification and recovery. It would be nice to have the possibility to configure this in values.yam.

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
      and signed the CLA.
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [x] I have added necessary documentation within the code base (if
      appropriate).
