### PR TITLE
chore(kratos): fix kratos chart values.yaml to align with manifest files

### DIFF
--- a/helm/charts/kratos/values.yaml
+++ b/helm/charts/kratos/values.yaml
@@ -72,6 +72,8 @@ ingress:
 
 kratos:
   development: false
+  # autoMigrate is relying on a simple initContainer mechanism
+  # Do not turn it on if the replicaCount > 1
   autoMigrate: false
 
 #  You can add multiple identity schemas here
@@ -127,24 +129,27 @@ kratos:
 
     secrets: {}
 
-deployment:
-  resources: {}
-  #  We usually recommend not to specify default resources and to leave this as a conscious
-  #  choice for the user. This also increases chances charts run on environments with little
-  #  resources, such as Minikube. If you do want to specify resources, uncomment the following
-  #  lines, adjust them as necessary, and remove the curly braces after 'resources:'.
-  #  limits:
-  #    cpu: 100m
-  #    memory: 128Mi
-  #  requests:
-  #    cpu: 100m
-  #  memory: 128Mi
+# The resources requests/limits for Kratos container
+resources: {}
+#  limits:
+#    cpu: 100m
+#    memory: 128Mi
+#  requests:
+#    cpu: 100m
+#  memory: 128Mi
 
-  # Node labels for pod assignment.
-  nodeSelector: {}
-  # If you do want to specify node labels, uncomment the following
-  # lines, adjust them as necessary, and remove the curly braces after 'annotations:'.
-  #   foo: bar
+# Node labels for pod assignment.
+nodeSelector: {}
+# If you do want to specify node labels, uncomment the following
+# lines, adjust them as necessary, and remove the curly braces after 'annotations:'.
+#   foo: bar
+
+# Configure node tolerations.
+tolerations: []
+
+
+deployment:
+
 
   extraEnv: []
 
@@ -172,9 +177,6 @@ deployment:
       # Default value: false.
       # useHostIP: true
 
-  # Configure node tolerations.
-  tolerations: []
-
   labels: {}
   #      If you do want to specify additional labels, uncomment the following
   #      lines, adjust them as necessary, and remove the curly braces after 'labels:'.
@@ -193,7 +195,7 @@ deployment:
   #   - name: postgresql-tls
   #     mountPath: "/etc/postgresql-tls"
   #     readOnly: true
-  
+
   annotations: {}
   #      If you do want to specify annotations, uncomment the following
   #      lines, adjust them as necessary, and remove the curly braces after 'annotations:'.


### PR DESCRIPTION
## Proposed changes

This PR fixes Kratos chart's `value.yaml` so it aligns with the actual manifest files. For example, in the `deployment.yaml`, it uses `.Values.resources` but in `value.yaml` it says the `resources` goes under the `deployment` key.

This PR also contains some minor comments change on the `value.yaml` aimed at reducing confusion. 

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
      and signed the CLA.
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [x] I have added necessary documentation within the code base (if
      appropriate).

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->

I do wonder if the `autoMigrate` should be true by default. I think this might fix most users interest.