### PR TITLE
Added extraInitContainers to Kratos helm chart

### DIFF
--- a/helm/charts/kratos/templates/deployment.yaml
+++ b/helm/charts/kratos/templates/deployment.yaml
@@ -36,8 +36,12 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
     {{- end }}
-    {{- if .Values.kratos.autoMigrate }}
+    {{- if or .Values.kratos.autoMigrate .Values.deployment.extraInitContainers}}
       initContainers:
+        {{- if .Values.deployment.extraInitContainers }}
+{{ tpl .Values.deployment.extraInitContainers . | indent 8 }}
+        {{- end }}
+        {{- if .Values.kratos.autoMigrate }}
         -
           name: {{ .Chart.Name }}-automigrate
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
@@ -106,6 +110,7 @@ spec:
           envFrom:
           - secretRef:
               name: {{ .Values.deployment.environmentSecretsName }}
+        {{- end}}
         {{- end}}
     {{- end}}
       volumes:

--- a/helm/charts/kratos/values.yaml
+++ b/helm/charts/kratos/values.yaml
@@ -196,6 +196,11 @@ deployment:
   #     mountPath: "/etc/postgresql-tls"
   #     readOnly: true
 
+  # If you want to add extra init containers. These are processed before the migration init container.
+  # extraInitContainers: |
+  #  - name: ...
+  #    image: ...
+  
   annotations: {}
   #      If you do want to specify annotations, uncomment the following
   #      lines, adjust them as necessary, and remove the curly braces after 'annotations:'.


### PR DESCRIPTION
## Related issue

Implementation of the following discussion:
[https://github.com/ory/kratos/discussions/1111](https://github.com/ory/kratos/discussions/1111)

@tricky42 

## Proposed changes

The change is done because I needed to execute an init container so I could download cockroachdb credentials to connect to the database. The "extraInitContainers" is placed **before** the migration init container in the deployment template file so the migration can have the proper credentials to connect to the bd when executed. 

Maybe I should name the "extraInitContainers" "preExtraInitContainers"?

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
      and signed the CLA.
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added necessary documentation within the code base (if
      appropriate).

## Further comments

This is my first pull request ever, so sorry beforehand if I mistake something. 

As an example on how I used it:
```
...
deployment:
  annotations: {}
  environmentSecretsName: null
  extraEnv: []
  labels: {}
  nodeSelector: {}
  resources: {}
  tolerations: []
  tracing:
    datadog:
      enabled: false
  extraInitContainers: |
    - name: init-certs
      image: cockroachdb/cockroach-k8s-request-cert:0.4
      imagePullPolicy: IfNotPresent
      command:
      - "/bin/ash"
      - "-ecx"
      - "/request-cert -namespace=${POD_NAMESPACE} -certs-dir=/cockroach-certs -type=client -user=root -symlink-ca-from=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt && chown -R 100:101 /cockroach-certs"
      env:
      - name: POD_NAMESPACE
        valueFrom:
          fieldRef:
            fieldPath: metadata.namespace
      volumeMounts:
      - name: client-certs
        mountPath: /cockroach-certs
  extraVolumes:
    - name: client-certs
  extraVolumeMounts:
    - name: client-certs
      mountPath: /cockroach-certs
...
```