### PR TITLE
fix(hydra): fix values for maester in helm chart

### DIFF
--- a/helm/charts/hydra/values.yaml
+++ b/helm/charts/hydra/values.yaml
@@ -218,12 +218,14 @@ affinity: {}
 # Configures controller setup
 maester:
   enabled: true
-  # Values for the hydra admin service arguments to hydra-maester
-  adminService: {}
-    # The service name value may need to be set if you use
-    # `fullnameOverride` for the parent chart
-    # name:
 
-    # You only need to set this port if you change the value for
-    # `service.admin.port` in the parent chart
-    # port:
+  # Values for the hydra admin service arguments to hydra-maester
+  hydra-maester:
+    adminService: {}
+      # The service name value may need to be set if you use
+      # `fullnameOverride` for the parent chart
+      # name:
+
+      # You only need to set this port if you change the value for
+      # `service.admin.port` in the parent chart
+      # port:


### PR DESCRIPTION
The values for hydra-maester aren't passed to the child chart. This fixes it.