### PR TITLE
feat: Add lifecycle values on deployment

### DIFF
--- a/helm/charts/hydra/templates/deployment.yaml
+++ b/helm/charts/hydra/templates/deployment.yaml
@@ -163,6 +163,8 @@ spec:
             {{- toYaml .Values.deployment.resources | nindent 12 }}
           securityContext:
             {{- toYaml .Values.deployment.securityContext | nindent 12 }}
+          lifecycle:
+            {{- toYaml .Values.deployment.lifecycle | nindent 12 }}
       {{- if .Values.priorityClassName }}
       priorityClassName: {{ .Values.priorityClassName }}
       {{- end }}

--- a/helm/charts/hydra/values.yaml
+++ b/helm/charts/hydra/values.yaml
@@ -143,6 +143,8 @@ deployment:
     allowPrivilegeEscalation: false
     privileged: false
 
+  lifecycle: {}
+
   labels: {}
   #      If you do want to specify additional labels, uncomment the following
   #      lines, adjust them as necessary, and remove the curly braces after 'labels:'.


### PR DESCRIPTION
## Related issue

None. The change is very simple.

## Proposed changes

Existing deployment.yaml doesn't have `lifecycle` hook. We want to add preStop hook to the deployment.yaml, so we add a new helm values `.Values.deployment.lifecycle` for this.

## Checklist

- [X] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
      and signed the CLA.
- [X] I have read the [security policy](../security/policy).
- [X] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added necessary documentation within the code base (if
      appropriate).

