### PR TITLE
feat: make secret management optional

### DIFF
--- a/helm/charts/oathkeeper/templates/deployment-controller.yaml
+++ b/helm/charts/oathkeeper/templates/deployment-controller.yaml
@@ -51,7 +51,7 @@ spec:
             name: {{ include "oathkeeper.fullname" . }}-rules
         - name: {{ include "oathkeeper.name" . }}-secrets-volume
           secret:
-            secretName: {{ include "oathkeeper.fullname" . }}
+            secretName: {{ empty .Values.secret.name | ternary (include "oathkeeper.fullname" .) (.Values.secret.name) }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
@@ -60,7 +60,7 @@ spec:
           env:
             {{- if .Values.oathkeeper.mutatorIdTokenJWKs }}
             - name: MUTATORS_ID_TOKEN_CONFIG_JWKS_URL
-              value: "file:///etc/secrets/mutator.id_token.jwks.json"
+              value: "file://{{ .Values.secret.mountPath }}/{{ .Values.secret.filename }}"
             {{- end }}
             {{- if .Values.deployment.tracing.datadog.enabled }}
             - name: TRACING_PROVIDER
@@ -89,7 +89,7 @@ spec:
               mountPath: /etc/rules
               readOnly: true
             - name: {{ include "oathkeeper.name" . }}-secrets-volume
-              mountPath: /etc/secrets
+              mountPath: {{ .Values.secret.mountPath }}
               readOnly: true
           ports:
             - name: http-api

--- a/helm/charts/oathkeeper/templates/deployment-sidecar.yaml
+++ b/helm/charts/oathkeeper/templates/deployment-sidecar.yaml
@@ -42,7 +42,7 @@ spec:
           emptyDir: {}
         - name: {{ include "oathkeeper.name" . }}-secrets-volume
           secret:
-            secretName: {{ include "oathkeeper.fullname" . }}
+            secretName: {{ empty .Values.secret.name | ternary (include "oathkeeper.fullname" .) (.Values.secret.name) }}
       initContainers:
         - name: init
           image: busybox:1
@@ -66,7 +66,7 @@ spec:
           env:
             {{- if .Values.oathkeeper.mutatorIdTokenJWKs }}
             - name: MUTATORS_ID_TOKEN_CONFIG_JWKS_URL
-              value: "file:///etc/secrets/mutator.id_token.jwks.json"
+              value: "file://{{ .Values.secret.mountPath }}/{{ .Values.secret.filename }}"
             {{- end }}
           volumeMounts:
             - name: {{ include "oathkeeper.name" . }}-config-volume
@@ -76,7 +76,7 @@ spec:
               mountPath: /etc/rules
               readOnly: true
             - name: {{ include "oathkeeper.name" . }}-secrets-volume
-              mountPath: /etc/secrets
+              mountPath: {{ .Values.secret.mountPath }}
               readOnly: true
           ports:
             - name: http-api

--- a/helm/charts/oathkeeper/templates/secrets.yaml
+++ b/helm/charts/oathkeeper/templates/secrets.yaml
@@ -1,7 +1,8 @@
+{{- if .Values.secret.manage }}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "oathkeeper.fullname" . }}
+  name: {{ empty .Values.secret.name | ternary (include "oathkeeper.fullname" .) (.Values.secret.name) }}
   {{- if .Release.Namespace }}
   namespace: {{ .Release.Namespace }}
   {{- end }}
@@ -10,5 +11,6 @@ metadata:
 type: Opaque
 data:
 {{- if .Values.oathkeeper.mutatorIdTokenJWKs }}
-  "mutator.id_token.jwks.json": {{ default "" .Values.oathkeeper.mutatorIdTokenJWKs | b64enc | quote }}
+  "{{ .Values.secret.filename }}": {{ default "" .Values.oathkeeper.mutatorIdTokenJWKs | b64enc | quote }}
 {{- end}}
+{{- end }}

--- a/helm/charts/oathkeeper/values.yaml
+++ b/helm/charts/oathkeeper/values.yaml
@@ -130,6 +130,21 @@ oathkeeper:
   # used as it will have no effect once "managedAccessRules" is disabled.
   managedAccessRules: true
 
+secret:
+  # set to true for this helm chart to manage the secret
+  # set to false for this helm chart to NOT manage the secret
+  # defaults to true
+  manage: true
+
+  # name of the secret to use
+  # if empty, defaults to {{ include "oathkeeper.fullname" . }}
+  name: ""
+
+  # default mount path for the kubernetes secret
+  mountPath: /etc/secrets
+  # default filename of JWKS (mounted as secret)
+  filename: mutator.id_token.jwks.json
+
 deployment: 
   resources: {}
   #  We usually recommend not to specify default resources and to leave this as a conscious


### PR DESCRIPTION
This PR makes secret management optional for the helm chart.  This allows external management of the JWKS secret data (including rotation, etc).

## Related issue

#120 

## Proposed changes

When `secret.manage: false`, the helm chart will not manage the secret.  This allows external management of the JWKS secret data (including rotation, etc).

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
      and signed the CLA.
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added necessary documentation within the code base (if
      appropriate).