### PR TITLE
fix(kratos): respect value of deployment.extraEnv

### DIFF
--- a/helm/charts/kratos/Chart.yaml
+++ b/helm/charts/kratos/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 appVersion: "0.6.3-alpha.1"
 description: A ORY Kratos Helm chart for Kubernetes
 name: kratos
-version: 0.13.0
+version: 0.13.1
 type: application

--- a/helm/charts/kratos/templates/deployment.yaml
+++ b/helm/charts/kratos/templates/deployment.yaml
@@ -108,8 +108,8 @@ spec:
                 secretKeyRef:
                   name: {{ include "kratos.secretname" . }}
                   key: smtpConnectionURI
-          {{- end}}
-          {{- if .Values.deployment.tracing.datadog.enabled }}
+            {{- end}}
+            {{- if .Values.deployment.tracing.datadog.enabled }}
             - name: TRACING_PROVIDER
               value: datadog
             - name: DD_ENV
@@ -124,6 +124,9 @@ spec:
                 fieldRef:
                   fieldPath: status.hostIP
             {{- end }}
+            {{- end }}
+            {{- if .Values.deployment.extraEnv }}
+{{ toYaml .Values.deployment.extraEnv | indent 12 }}
             {{- end }}
         {{- if .Values.deployment.environmentSecretsName }}
           envFrom:


### PR DESCRIPTION
## Related issue

Despite this variable is stated in values file, deployment for kratos doesn't use it.

## Proposed changes

Add extraEnv to Deployment file

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
      and signed the CLA.
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added necessary documentation within the code base (if
      appropriate).

