### PR TITLE
feat: allow configuring probe values for kratos & keto

### DIFF
--- a/helm/charts/hydra/templates/deployment.yaml
+++ b/helm/charts/hydra/templates/deployment.yaml
@@ -83,16 +83,12 @@ spec:
             httpGet:
               path: /health/alive
               port: http-admin
-            initialDelaySeconds: {{ .Values.deployment.livenessProbe.initialDelaySeconds }}
-            periodSeconds: {{ .Values.deployment.livenessProbe.periodSeconds }}
-            failureThreshold: {{ .Values.deployment.livenessProbe.failureThreshold }}
+            {{- toYaml .Values.deployment.livenessProbe | nindent 12 }}
           readinessProbe:
             httpGet:
               path: /health/ready
               port: http-admin
-            initialDelaySeconds: {{ .Values.deployment.readinessProbe.initialDelaySeconds }}
-            periodSeconds: {{ .Values.deployment.readinessProbe.periodSeconds }}
-            failureThreshold: {{ .Values.deployment.readinessProbe.failureThreshold }}
+            {{- toYaml .Values.deployment.readinessProbe | nindent 12 }}
           env:
             {{- if .Values.deployment.tracing.datadog.enabled }}
             - name: TRACING_PROVIDER

--- a/helm/charts/keto/templates/deployment.yaml
+++ b/helm/charts/keto/templates/deployment.yaml
@@ -50,10 +50,12 @@ spec:
             httpGet:
               path: /health/alive
               port: http-write
+            {{- toYaml .Values.deployment.livenessProbe | nindent 12 }}
           readinessProbe:
             httpGet:
               path: /health/ready
               port: http-write
+          {{- toYaml .Values.deployment.readinessProbe | nindent 12 }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           env:

--- a/helm/charts/keto/values.yaml
+++ b/helm/charts/keto/values.yaml
@@ -167,3 +167,14 @@ tracing:
 tolerations: []
 
 affinity: {}
+
+# Configure the probes for when the deployment is considered ready and ongoing health check
+deployment:
+  livenessProbe:
+    initialDelaySeconds: 30
+    periodSeconds: 10
+    failureThreshold: 5
+  readinessProbe:
+    initialDelaySeconds: 30
+    periodSeconds: 10
+    failureThreshold: 5

--- a/helm/charts/kratos/templates/deployment.yaml
+++ b/helm/charts/kratos/templates/deployment.yaml
@@ -145,10 +145,12 @@ spec:
             httpGet:
               path: /health/alive
               port: http-admin
+            {{- toYaml .Values.deployment.livenessProbe | nindent 12 }}
           readinessProbe:
             httpGet:
               path: /health/ready
               port: http-admin
+            {{- toYaml .Values.deployment.readinessProbe | nindent 12 }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           securityContext:

--- a/helm/charts/kratos/values.yaml
+++ b/helm/charts/kratos/values.yaml
@@ -237,6 +237,16 @@ deployment:
   # https://kubernetes.io/docs/tasks/inject-data-application/distribute-credentials-secure/#configure-all-key-value-pairs-in-a-secret-as-container-environment-variables
   environmentSecretsName:
 
+  # Configure the probes for when the deployment is considered ready and ongoing health check
+  livenessProbe:
+    initialDelaySeconds: 30
+    periodSeconds: 10
+    failureThreshold: 5
+  readinessProbe:
+    initialDelaySeconds: 30
+    periodSeconds: 10
+    failureThreshold: 5
+
 job:
   annotations: {}
 


### PR DESCRIPTION
## Related issue

Similar to #252, during deployment we noticed that the readiness check of the Kratos service took longer than the default `timeoutSeconds` parameter. However, there is no option to adapt this parameter. 

## Proposed changes

This PR allows for configuring custom probe timeouts by adding new values to the chart for Kratos and Keto, similarly as #252 did for Hydra.

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
      and signed the CLA.
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added necessary documentation within the code base (if
      appropriate).

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
