### PR TITLE
feat: add Istio support to kratos

### DIFF
--- a/helm/charts/kratos/templates/deployment.yaml
+++ b/helm/charts/kratos/templates/deployment.yaml
@@ -36,6 +36,9 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
     {{- end }}
+    {{- if .Values.serviceAccount.enabled }}
+      serviceAccountName: {{ default (include "kratos.fullname" . ) .Values.serviceAccount.name }}
+    {{- end }}
     {{- if .Values.deployment.extraInitContainers}}
       initContainers:
         {{- if .Values.deployment.extraInitContainers }}

--- a/helm/charts/kratos/templates/job-migration.yaml
+++ b/helm/charts/kratos/templates/job-migration.yaml
@@ -24,12 +24,19 @@ spec:
         {{- toYaml . | nindent 8 }}
     {{- end }}
     spec:
+      {{- if .Values.serviceAccount.enabled }}
+      serviceAccountName: {{ default (include "kratos.fullname" . ) .Values.serviceAccount.name }}
+      {{- end }}
       containers:
       - name: {{ .Chart.Name }}-automigrate
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
-        command: ["kratos"]
-        args: ["migrate", "sql", "-e", "--yes"]
+        {{- if .Values.job.args }}
+        args: {{ .Values.job.args | toYaml | nindent 10 }}
+        {{- end }}
+        {{- if .Values.job.command }}
+        command: {{ .Values.job.command | toYaml | nindent 10 }}
+        {{- end }}
         env:
           - name: DSN
             valueFrom:

--- a/helm/charts/kratos/templates/serviceaccount.yaml
+++ b/helm/charts/kratos/templates/serviceaccount.yaml
@@ -1,0 +1,15 @@
+{{- if and (.Values.serviceAccount.enabled) (not .Values.serviceAccount.name) }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "kratos.fullname" . }}
+  {{- if .Release.Namespace }}
+  namespace: {{ .Release.Namespace }}
+  {{- end }}
+  labels:
+    {{- include "kratos.labels" . | nindent 4 }}
+  annotations:
+    helm.sh/hook-weight: "0"
+    helm.sh/hook: "pre-install, pre-upgrade"
+    helm.sh/hook-delete-policy: "before-hook-creation"
+{{- end }}

--- a/helm/charts/kratos/values.yaml
+++ b/helm/charts/kratos/values.yaml
@@ -236,6 +236,26 @@ deployment:
 
 job:
   annotations: {}
+  #  If you'd like to use Istio and auto-migration is enabled edit the command and args for the migration job
+  #  Please note Kratos container image is very light and doesn't include curl. You'd need to build your own
+  #  e.g.
+  #  args: []
+  #  command:
+  #    - /bin/sh
+  #    - -ec
+  #    - |
+  #      kratos migrate sql -e --yes
+  #      x=$(echo $?); curl -fsI -X POST http://localhost:15020/quitquitquit && exit $x
+  command: ["kratos"]
+  args: ["migrate", "sql", "-e", "--yes"]
 
 # Configure node affinity
 affinity: {}
+
+## Pod Service Account
+## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
+##
+serviceAccount:
+  enabled: false
+  ## Name of an already existing service account. Setting this value disables the automatic service account creation.
+  # name:


### PR DESCRIPTION
## Related issue

N/A

## Proposed changes

This PR adds opt-in configuration options to use Kratos with Istio

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
      and signed the CLA.
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [x] I have added necessary documentation within the code base (if
      appropriate).

## Further comments

This PR doesn't introduce any changes to existing users. All the modifications are configurable and optional.

This PR adds the following:

- Service account (disabled by default) for the deployment and the migration job. I think having a dedicated service account is best practice any way, but in the case of Istio, it's useful to write [AuthorizationPolicy](https://istio.io/latest/docs/reference/config/security/authorization-policy/)
- There was a Kubernetes proposal for sidecars that got stalled. For now, any cluster using service meshes (Linkerd, istio) needs to manage jobs differently. See https://github.com/istio/istio/issues/6324. This PR makes the args and command of the migration job configurable for this. I've written an example in the `values.yaml` file for reference
