### PR TITLE
fix: use fullname instead of name

### DIFF
--- a/helm/charts/hydra-maester/templates/deployment.yaml
+++ b/helm/charts/hydra-maester/templates/deployment.yaml
@@ -46,7 +46,7 @@ spec:
           terminationMessagePolicy: File
           securityContext:
             {{- toYaml .Values.deployment.securityContext | nindent 12 }}
-      serviceAccountName: {{ include "hydra-maester.name" . }}-account
+      serviceAccountName: {{ include "hydra-maester.fullname" . }}-account
       automountServiceAccountToken: {{ .Values.deployment.automountServiceAccountToken }}
       {{- if .Values.priorityClassName }}
       priorityClassName: {{ .Values.priorityClassName }}

--- a/helm/charts/hydra-maester/templates/rbac.yaml
+++ b/helm/charts/hydra-maester/templates/rbac.yaml
@@ -2,13 +2,13 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ include "hydra-maester.name" . }}-account
+  name: {{ include "hydra-maester.fullname" . }}-account
   namespace:  {{ .Release.Namespace }}
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: {{ include "hydra-maester.name" . }}-role
+  name: {{ include "hydra-maester.fullname" . }}-role
   namespace:  {{ .Release.Namespace }}
 rules:
   - apiGroups: ["hydra.ory.sh"]
@@ -21,21 +21,21 @@ rules:
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: {{ include "hydra-maester.name" . }}-role-binding
+  name: {{ include "hydra-maester.fullname" . }}-role-binding
   namespace:  {{ .Release.Namespace }}
 subjects:
   - kind: ServiceAccount
-    name: {{ include "hydra-maester.name" . }}-account # Service account assigned to the controller pod.
+    name: {{ include "hydra-maester.fullname" . }}-account # Service account assigned to the controller pod.
     namespace:  {{ .Release.Namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ include "hydra-maester.name" . }}-role
+  name: {{ include "hydra-maester.fullname" . }}-role
 ---
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: {{ include "hydra-maester.name" . }}-role-{{ .Release.Namespace }}
+  name: {{ include "hydra-maester.fullname" . }}-role-{{ .Release.Namespace }}
   namespace:  {{ .Release.Namespace }}
 rules:
   - apiGroups: [""]
@@ -45,18 +45,18 @@ rules:
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: {{ include "hydra-maester.name" . }}-role-binding-{{ .Release.Namespace }}
+  name: {{ include "hydra-maester.fullname" . }}-role-binding-{{ .Release.Namespace }}
   namespace:  {{ .Release.Namespace }}
 subjects:
   - kind: ServiceAccount
-    name: {{ include "hydra-maester.name" . }}-account # Service account assigned to the controller pod.
+    name: {{ include "hydra-maester.fullname" . }}-account # Service account assigned to the controller pod.
     namespace:  {{ .Release.Namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: {{ include "hydra-maester.name" . }}-role-{{ .Release.Namespace }}
+  name: {{ include "hydra-maester.fullname" . }}-role-{{ .Release.Namespace }}
 
-{{- $name := include "hydra-maester.name" . -}}
+{{- $name := include "hydra-maester.fullname" . -}}
 {{- $namespace := .Release.Namespace -}}
 {{- range .Values.enabledNamespaces }}
 ---

--- a/helm/charts/oathkeeper-maester/templates/deployment.yaml
+++ b/helm/charts/oathkeeper-maester/templates/deployment.yaml
@@ -61,7 +61,7 @@ spec:
           {{- end }}
           securityContext:
             {{- toYaml .Values.deployment.securityContext | nindent 12 }}
-      serviceAccountName: {{ include "oathkeeper-maester.name" . }}-account
+      serviceAccountName: {{ include "oathkeeper-maester.fullname" . }}-account
       automountServiceAccountToken: {{ .Values.deployment.automountServiceAccountToken }}
       dnsPolicy: ClusterFirst
       restartPolicy: Always

--- a/helm/charts/oathkeeper-maester/templates/rbac.yaml
+++ b/helm/charts/oathkeeper-maester/templates/rbac.yaml
@@ -2,13 +2,13 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ include "oathkeeper-maester.name" . }}-account
+  name: {{ include "oathkeeper-maester.fullname" . }}-account
   namespace:  {{ .Release.Namespace }}
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: {{ include "oathkeeper-maester.name" . }}-role
+  name: {{ include "oathkeeper-maester.fullname" . }}-role
   # namespace:  {{ .Release.Namespace }}
 rules:
   - apiGroups: ["oathkeeper.ory.sh"]
@@ -24,7 +24,7 @@ rules:
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: {{ include "oathkeeper-maester.name" . }}-role-binding
+  name: {{ include "oathkeeper-maester.fullname" . }}-role-binding
   namespace:  {{ .Release.Namespace }}
 subjects:
   - kind: ServiceAccount
@@ -33,4 +33,4 @@ subjects:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ include "oathkeeper-maester.name" . }}-role
+  name: {{ include "oathkeeper-maester.fullname" . }}-role


### PR DESCRIPTION
## Related issue
- Fixes https://github.com/ory/k8s/issues/138
<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@aeneasr`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers either in the Github Discusssions in this repository or
join the [ORY Chat](https://www.ory.sh/chat).
-->

## Proposed changes
Use `fullname` instead of name in templates to allow multiple installations.
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
      and signed the CLA.
- [ ] I have read the [security policy](../security/policy).
- [ ] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added necessary documentation within the code base (if
      appropriate).

## Further comments

Recommend way of installing multiple releases:

```bash
helm install oathkeeper-maester ./helm/charts/oathkeeper-maester --namespace foo1
helm install oathkeeper-maester-2 ./helm/charts/oathkeeper-maester --namespace foo2
```

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
