### PR TITLE
feat: support extra volumes and mounts in migration job

### DIFF
--- a/helm/charts/keto/templates/job-migration.yaml
+++ b/helm/charts/keto/templates/job-migration.yaml
@@ -32,9 +32,12 @@ spec:
         command: [ "keto" ]
         args: [ "migrate", "up", "-y", "--all-namespaces", "--config", "/etc/config/keto.yaml" ]
         volumeMounts:
-        - name: {{ include "keto.name" . }}-config-volume
-          mountPath: /etc/config
-          readOnly: true
+          - name: {{ include "keto.name" . }}-config-volume
+            mountPath: /etc/config
+            readOnly: true
+        {{- with .Values.extraVolumeMounts }}
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
         env:
           - name: DSN
             valueFrom:
@@ -48,5 +51,8 @@ spec:
         - name: {{ include "keto.name" . }}-config-volume
           configMap:
             name: {{ include "keto.fullname" . }}-migrate
+      {{- with .Values.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
   backoffLimit: 10
 {{- end }}


### PR DESCRIPTION
## Proposed changes

Extended keto helm chart to support extra volumes and mounts in migration job.
If DSN is referencing to a file with a certificate this certificate needs to be mounted, currently, you can do it only if you mount the certificate in the CM that is already defined in the chart. This will not be suitable in most cases as certificates usually are stored in separate resources like secrets. I have added the same way of extra mounting volumes as it's done in the keto deployment.

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
      and signed the CLA.
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added necessary documentation within the code base (if
      appropriate).

## Further comments

@Demonsthere please take a look
FYI @aeneasr 
