### PR TITLE
feat: allow probe successThreshold & timeoutSeconds configuration

### DIFF
--- a/helm/charts/hydra/values.yaml
+++ b/helm/charts/hydra/values.yaml
@@ -236,10 +236,14 @@ deployment:
     initialDelaySeconds: 30
     periodSeconds: 10
     failureThreshold: 5
+    successThreshold: 1
+    timeoutSeconds: 1
   readinessProbe:
     initialDelaySeconds: 30
     periodSeconds: 10
     failureThreshold: 5
+    successThreshold: 1
+    timeoutSeconds: 1
 
   # https://github.com/kubernetes/kubernetes/issues/57601
   automountServiceAccountToken: false

--- a/helm/charts/keto/values.yaml
+++ b/helm/charts/keto/values.yaml
@@ -174,7 +174,11 @@ deployment:
     initialDelaySeconds: 30
     periodSeconds: 10
     failureThreshold: 5
+    successThreshold: 1
+    timeoutSeconds: 1
   readinessProbe:
     initialDelaySeconds: 30
     periodSeconds: 10
     failureThreshold: 5
+    successThreshold: 1
+    timeoutSeconds: 1

--- a/helm/charts/kratos/values.yaml
+++ b/helm/charts/kratos/values.yaml
@@ -242,10 +242,14 @@ deployment:
     initialDelaySeconds: 30
     periodSeconds: 10
     failureThreshold: 5
+    successThreshold: 1
+    timeoutSeconds: 1
   readinessProbe:
     initialDelaySeconds: 30
     periodSeconds: 10
     failureThreshold: 5
+    successThreshold: 1
+    timeoutSeconds: 1
 
 job:
   annotations: {}


### PR DESCRIPTION
## Proposed changes

Allow configuration of `successThreshold` & `timeoutSeconds` for liveness and readiness probes,which I wanted to achieve with #268 but apparently forgot to configure.

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
      and signed the CLA.
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added necessary documentation within the code base (if
      appropriate).

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
