### PR TITLE
feat: Upgrade kratos to 0.6 (quick win)

### DIFF
--- a/helm/charts/kratos/templates/deployment.yaml
+++ b/helm/charts/kratos/templates/deployment.yaml
@@ -66,7 +66,7 @@ spec:
           args: [
             "serve",
             "all",
-            "--watch-courier" # Will be configurable, check out https://github.com/ory/k8s/issues/285
+            "--watch-courier", # Will be configurable, check out https://github.com/ory/k8s/issues/285
             {{- if .Values.kratos.development }}
             "--dev",
             {{- end}}

--- a/helm/charts/kratos/templates/deployment.yaml
+++ b/helm/charts/kratos/templates/deployment.yaml
@@ -66,6 +66,7 @@ spec:
           args: [
             "serve",
             "all",
+            "--watch-courier" # Will be configurable, check out https://github.com/ory/k8s/issues/285
             {{- if .Values.kratos.development }}
             "--dev",
             {{- end}}

--- a/helm/charts/kratos/values.yaml
+++ b/helm/charts/kratos/values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: oryd/kratos
-  tag: v0.5.5-alpha.1-sqlite
+  tag: v0.6.3-alpha.1-sqlite
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []
@@ -224,7 +224,7 @@ deployment:
   # extraInitContainers: |
   #  - name: ...
   #    image: ...
-  
+
   annotations: {}
   #      If you do want to specify annotations, uncomment the following
   #      lines, adjust them as necessary, and remove the curly braces after 'annotations:'.


### PR DESCRIPTION
## Related issue

#285 

## Proposed changes

This PR implements the first cut of option 2 in #285. 
It's not a complete solution but it will give user a way to deploy v0.6 to production right now.


## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
      and signed the CLA.
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added necessary documentation within the code base (if
      appropriate).

## Further comments

It will be so great if we make a quick release for this. I am currently stuck on upgrading v0.5 -> v0.6. 
I have done all the code change and only realize the chart isn't ready yet . 
