### PR TITLE
feat: Uprade Kratos 0.6:  Courier StatefulSet, new auto migrate mechanism, changing default tag to non-sqlite version

### DIFF
--- a/helm/charts/kratos/templates/_helpers.tpl
+++ b/helm/charts/kratos/templates/_helpers.tpl
@@ -99,3 +99,20 @@ app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end -}}
+
+{{- define "kratos.courier.name" -}}
+{{- include "kratos.name" . }}-courier
+{{- end -}}
+
+{{/*
+Courier statefulset labels
+*/}}
+{{- define "kratos.courier.labels" -}}
+app.kubernetes.io/name: {{ include "kratos.courier.name" . }}
+helm.sh/chart: {{ include "kratos.chart" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}

--- a/helm/charts/kratos/templates/_helpers.tpl
+++ b/helm/charts/kratos/templates/_helpers.tpl
@@ -25,6 +25,14 @@ If release name contains chart name it will be used as a full name.
 {{- end -}}
 
 {{/*
+Name of the Automigrate Job
+It's unique per release
+*/}}
+{{- define "kratos.automigrate-job-name" -}}
+{{ include "kratos.fullname" . }}-automigrate-{{ .Release.Revision }}
+{{- end }}
+
+{{/*
 Create a secret name which can be overridden.
 */}}
 {{- define "kratos.secretname" -}}

--- a/helm/charts/kratos/templates/deployment.yaml
+++ b/helm/charts/kratos/templates/deployment.yaml
@@ -58,6 +58,13 @@ spec:
         {{- end }}
         {{- end }}
       automountServiceAccountToken: {{ .Values.automountServiceAccountToken }}
+      initContainers:
+        - name: wait-for-automigrate
+          image: "groundnuty/k8s-wait-for:v1.4"
+          imagePullPolicy: IfNotPresent
+          args:
+            - job
+            - {{ include "kratos.automigrate-job-name" . }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/helm/charts/kratos/templates/deployment.yaml
+++ b/helm/charts/kratos/templates/deployment.yaml
@@ -51,7 +51,10 @@ spec:
             name: {{ include "kratos.fullname" $root }}-template-{{ $method }}-{{ $result }}
         {{- end }}
         {{- end }}
-      automountServiceAccountToken: {{ .Values.automountServiceAccountToken }}
+      automountServiceAccountToken: {{ .Values.serviceAccount.enabled }}
+      {{- if .Values.serviceAccount.enabled }}
+      serviceAccountName: {{ default (include "kratos.fullname" . ) .Values.serviceAccount.name }}
+      {{- end }}
       initContainers:
         - name: wait-for-automigrate
           image: "groundnuty/k8s-wait-for:v1.4"

--- a/helm/charts/kratos/templates/job-migration.yaml
+++ b/helm/charts/kratos/templates/job-migration.yaml
@@ -3,23 +3,17 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: {{ include "kratos.fullname" . }}-automigrate
-  {{- if .Release.Namespace }}
-  namespace: {{ .Release.Namespace }}
-  {{- end }}
+  name: {{ include "kratos.automigrate-job-name" . }}
   labels:
 {{ include "kratos.labels" . | indent 4 }}
   annotations:
     {{- with .Values.job.annotations }}
       {{- toYaml . | nindent 4 }}
     {{- end }}
-    helm.sh/hook-weight: "1"
-    helm.sh/hook: "pre-install, pre-upgrade"
-    helm.sh/hook-delete-policy: "before-hook-creation"
 spec:
   template:
     {{- with .Values.job.annotations }}
-    metadata: 
+    metadata:
       annotations:
         {{- toYaml . | nindent 8 }}
     {{- end }}

--- a/helm/charts/kratos/templates/role.yaml
+++ b/helm/charts/kratos/templates/role.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.rbac.create }}
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ include "kratos.fullname" . }}
+  labels:
+    {{- include "kratos.labels" . | nindent 4 }}
+rules:
+  # Needed by initContainer to check monitor whether migration job has been done
+  - apiGroups: ["batch"]
+    resources: ["jobs"]
+    verbs: ["get", "list", "watch"]
+{{- end }}

--- a/helm/charts/kratos/templates/rolebinding.yaml
+++ b/helm/charts/kratos/templates/rolebinding.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.rbac.create }}
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ include "kratos.fullname" . }}
+  labels:
+    {{- include "kratos.labels" . | nindent 4 }}
+roleRef:
+  kind: Role
+  name: {{ include "kratos.fullname" . }}
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+  - kind: ServiceAccount
+    name: {{ default (include "kratos.fullname" . ) .Values.serviceAccount.name }}
+{{- end }}

--- a/helm/charts/kratos/templates/service-headless-courier.yaml
+++ b/helm/charts/kratos/templates/service-headless-courier.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.standaloneCourier -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "kratos.fullname" . }}-courier
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "kratos.courier.labels" . | nindent 4 }}
+spec:
+  clusterIP: None
+  ports: []
+  selector:
+    app.kubernetes.io/name: {{ include "kratos.courier.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/helm/charts/kratos/templates/serviceaccount.yaml
+++ b/helm/charts/kratos/templates/serviceaccount.yaml
@@ -1,0 +1,8 @@
+{{- if and (.Values.serviceAccount.enabled) (not .Values.serviceAccount.name) }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "kratos.fullname" . }}
+  labels:
+    {{- include "kratos.labels" . | nindent 4 }}
+{{- end }}

--- a/helm/charts/kratos/templates/statefulset-courier.yaml
+++ b/helm/charts/kratos/templates/statefulset-courier.yaml
@@ -14,7 +14,7 @@ metadata:
       {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
-  # Due to some limitation in the persistence layer, this has to be a singleton
+  # Due to some limitation in the Kratos persistence layer, this has to be a singleton
   replicas: 1
   serviceName: {{ include "kratos.fullname" . }}-courier
   selector:
@@ -142,23 +142,6 @@ spec:
           - secretRef:
               name: {{ .Values.deployment.environmentSecretsName }}
         {{- end}}
-          ports:
-            - name: http-admin
-              containerPort: {{ .Values.kratos.config.serve.admin.port }}
-              protocol: TCP
-            - name: http-public
-              containerPort: {{ .Values.kratos.config.serve.public.port }}
-              protocol: TCP
-          livenessProbe:
-            httpGet:
-              path: /health/alive
-              port: http-admin
-            {{- toYaml .Values.deployment.livenessProbe | nindent 12 }}
-          readinessProbe:
-            httpGet:
-              path: /health/ready
-              port: http-admin
-            {{- toYaml .Values.deployment.readinessProbe | nindent 12 }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           securityContext:

--- a/helm/charts/kratos/templates/statefulset-courier.yaml
+++ b/helm/charts/kratos/templates/statefulset-courier.yaml
@@ -1,12 +1,11 @@
+{{- if .Values.kratos.standaloneCourier }}
+---
 apiVersion: apps/v1
-kind: Deployment
+kind: StatefulSet
 metadata:
   name: {{ include "kratos.fullname" . }}
-  {{- if .Release.Namespace }}
-  namespace: {{ .Release.Namespace }}
-  {{- end }}
   labels:
-{{ include "kratos.labels" . | indent 4 }}
+    {{- include "kratos.labels" . | nindent 4 }}
     {{- with .Values.deployment.labels }}
       {{- toYaml . | nindent 4 }}
     {{- end }}
@@ -15,7 +14,8 @@ metadata:
       {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
-  replicas: {{ .Values.replicaCount }}
+  # Due to some limitation in the persistence layer, this has to be a singleton
+  replicas: 1
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ include "kratos.name" . }}
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       labels:
-{{ include "kratos.labels" . | indent 8 }}
+        {{- include "kratos.labels" . | nindent 8 }}
         {{- with .Values.deployment.labels }}
           {{- toYaml . | nindent 8 }}
         {{- end }}
@@ -38,7 +38,7 @@ spec:
     {{- end }}
       volumes:
         {{- if .Values.deployment.extraVolumes }}
-{{ toYaml .Values.deployment.extraVolumes | indent 8 }}
+        {{- toYaml .Values.deployment.extraVolumes | nindent 8 }}
         {{- end }}
         - name: {{ include "kratos.name" . }}-config-volume
           configMap:
@@ -68,11 +68,8 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: ["kratos"]
           args: [
-            "serve",
-            "all",
-            {{- if .Values.kratos.embeddedCourier }}
-            "--watch-courier",
-            {{- end}}
+            "courier",
+            "watch",
             {{- if .Values.kratos.development }}
             "--dev",
             {{- end}}
@@ -81,7 +78,7 @@ spec:
           ]
           volumeMounts:
             {{- if .Values.deployment.extraVolumeMounts }}
-{{ toYaml .Values.deployment.extraVolumeMounts | indent 12 }}
+            {{- toYaml .Values.deployment.extraVolumeMounts | nindent 12 }}
             {{- end }}
             - name: {{ include "kratos.name" . }}-config-volume
               mountPath: /etc/config
@@ -134,7 +131,7 @@ spec:
             {{- end }}
             {{- end }}
             {{- if .Values.deployment.extraEnv }}
-{{ toYaml .Values.deployment.extraEnv | indent 12 }}
+            {{- toYaml .Values.deployment.extraEnv | nindent 12 }}
             {{- end }}
         {{- if .Values.deployment.environmentSecretsName }}
           envFrom:
@@ -174,3 +171,4 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
     {{- end }}
+{{- end }}

--- a/helm/charts/kratos/templates/statefulset-courier.yaml
+++ b/helm/charts/kratos/templates/statefulset-courier.yaml
@@ -3,9 +3,9 @@
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: {{ include "kratos.fullname" . }}
+  name: {{ include "kratos.fullname" . }}-courier
   labels:
-    {{- include "kratos.labels" . | nindent 4 }}
+    {{- include "kratos.courier.labels" . | nindent 4 }}
     {{- with .Values.deployment.labels }}
       {{- toYaml . | nindent 4 }}
     {{- end }}
@@ -16,14 +16,15 @@ metadata:
 spec:
   # Due to some limitation in the persistence layer, this has to be a singleton
   replicas: 1
+  serviceName: {{ include "kratos.fullname" . }}-courier
   selector:
     matchLabels:
-      app.kubernetes.io/name: {{ include "kratos.name" . }}
+      app.kubernetes.io/name: {{ include "kratos.courier.name" . }}
       app.kubernetes.io/instance: {{ .Release.Name }}
   template:
     metadata:
       labels:
-        {{- include "kratos.labels" . | nindent 8 }}
+        {{- include "kratos.courier.labels" . | nindent 8 }}
         {{- with .Values.deployment.labels }}
           {{- toYaml . | nindent 8 }}
         {{- end }}
@@ -63,7 +64,7 @@ spec:
         {{- tpl .Values.deployment.extraInitContainers . | nindent 8 }}
         {{- end }}
       containers:
-        - name: {{ .Chart.Name }}
+        - name: {{ .Chart.Name }}-courier
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: ["kratos"]

--- a/helm/charts/kratos/templates/statefulset-courier.yaml
+++ b/helm/charts/kratos/templates/statefulset-courier.yaml
@@ -52,7 +52,10 @@ spec:
             name: {{ include "kratos.fullname" $root }}-template-{{ $method }}-{{ $result }}
         {{- end }}
         {{- end }}
-      automountServiceAccountToken: {{ .Values.automountServiceAccountToken }}
+      automountServiceAccountToken: {{ .Values.serviceAccount.enabled }}
+      {{- if .Values.serviceAccount.enabled }}
+      serviceAccountName: {{ default (include "kratos.fullname" . ) .Values.serviceAccount.name }}
+      {{- end }}
       initContainers:
         - name: wait-for-automigrate
           image: "groundnuty/k8s-wait-for:v1.4"

--- a/helm/charts/kratos/values.yaml
+++ b/helm/charts/kratos/values.yaml
@@ -46,6 +46,21 @@ secret:
     helm.sh/hook-delete-policy: "before-hook-creation"
     helm.sh/resource-policy: "keep"
 
+# Create role for ServiceAccount
+# Required by default.
+# can be disabled if both of these are true:
+# 1. No RBAC control is installed in the cluster.
+# 2. You want to manage RBAC yourself.
+rbac:
+  create: true
+
+# Service account for all pods
+serviceAccount:
+  enabled: true
+  # Name of an already existing service account.
+  # Setting this value disables the automatic service account creation
+  # name:
+
 ingress:
   admin:
     enabled: false
@@ -155,9 +170,6 @@ resources: {}
 #  requests:
 #    cpu: 100m
 #  memory: 128Mi
-
-# https://github.com/kubernetes/kubernetes/issues/57601
-automountServiceAccountToken: false
 
 securityContext:
   capabilities:

--- a/helm/charts/kratos/values.yaml
+++ b/helm/charts/kratos/values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: oryd/kratos
-  tag: v0.5.5-alpha.1-sqlite
+  tag: v0.6.3-alpha.1
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []
@@ -79,9 +79,7 @@ ingress:
 
 kratos:
   development: false
-  # autoMigrate is relying on a simple initContainer mechanism
-  # Do not turn it on if the replicaCount > 1
-  autoMigrate: false
+  autoMigrate: true
 
 #  You can add multiple identity schemas here
 #  identitySchemas:
@@ -224,7 +222,7 @@ deployment:
   # extraInitContainers: |
   #  - name: ...
   #    image: ...
-  
+
   annotations: {}
   #      If you do want to specify annotations, uncomment the following
   #      lines, adjust them as necessary, and remove the curly braces after 'annotations:'.

--- a/helm/charts/kratos/values.yaml
+++ b/helm/charts/kratos/values.yaml
@@ -81,6 +81,15 @@ kratos:
   development: false
   autoMigrate: true
 
+  # Enable this will launch the embedded courier inside the Kratos main app
+  # Only enable it if you intend to run a single replica of Kratos
+  embeddedCourier: false
+
+  # Enable this will lanch a dedicated Courier StatefulSet with only 1 replica.
+  # Disable it if you intend to use SQLite.
+  # embeddedCourier and standaloneCourier can't be true at the same time
+  standaloneCourier: true
+
 #  You can add multiple identity schemas here
 #  identitySchemas:
 #    "identity.default.schema.json": |


### PR DESCRIPTION
## Related issue

Close #285

Close #286 

## Proposed changes

My apology for this relatively big PR. The amount of necessary changes are beyond my expectation too. 
I won't be unhappy if you reject this change. 

As per the discussion with @aeneasr in #285. This PR introduces a few changes:

1. Upgrade default tag to v0.6.3-alpha.1 (no SQLite)
2. Introduce a courier StatefulSet.
3. Enable standalone courier by default. 
4. Allow user to opt-in the `--watch-courier` option.

Some extra changes are necessary:
1. Stop using Helm hook as the auto migration mechanism. Instead, I use initContainer to proactively wait the completion of migration job. Helm hook is a client side feature, it gets executed before everything else, including other dependencies. It quickly break things, if the migration task relies on other ConfigMaps or chart dependencies.
2. In order to get point 1 working, I had to introduce rbac to the chart so initContainer can have access to Kube API's job resources. 
3. To support point 1 and 2, I have also slightly change that `automountServiceToken` is calculated instead of set. 

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
      and signed the CLA.
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [x] I have added necessary documentation within the code base (if
      appropriate).

## Further comments

I have been using the new chart on deploying my product to production.