### PR TITLE
fix: use the correct ServiceAccount name in the ClusterRoleBinding

### DIFF
--- a/helm/charts/oathkeeper-maester/templates/rbac.yaml
+++ b/helm/charts/oathkeeper-maester/templates/rbac.yaml
@@ -28,7 +28,7 @@ metadata:
   namespace:  {{ .Release.Namespace }}
 subjects:
   - kind: ServiceAccount
-    name: {{ include "oathkeeper-maester.name" . }}-account # Service account assigned to the controller pod.
+    name: {{ include "oathkeeper-maester.fullname" . }}-account # Service account assigned to the controller pod.
     namespace:  {{ .Release.Namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
## Proposed changes

#276 updated resource names to use `fullname`, but this role binding was overlooked.

The result is that the Maester service does not have the needed permissions to list Rule resources:

```
E0706 00:58:21.003914       1 reflector.go:138] pkg/mod/k8s.io/client-go@v0.20.2/tools/cache/reflector.go:167: Failed to watch *v1alpha1.Rule: failed to list *v1alpha1.Rule: rules.oathkeeper.ory.sh is forbidden: User "system:serviceaccount:default:test-oathkeeper-maester-account" cannot list resource "rules" in API group "oathkeeper.ory.sh" at the cluster scope
``` 

## Checklist

- [X ] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
      and signed the CLA.
- [ X] I have read the [security policy](../security/policy).
- [ X] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added necessary documentation within the code base (if
      appropriate).
