### PR TITLE
fix(hydra): correct format for secrets.system env value

### DIFF
--- a/helm/charts/hydra/templates/_helpers.tpl
+++ b/helm/charts/hydra/templates/_helpers.tpl
@@ -83,12 +83,12 @@ Generate the secrets.system value
 {{- define "hydra.secrets.system" -}}
   {{- if .Values.hydra.config.secrets.system -}}
     {{- if kindIs "slice" .Values.hydra.config.secrets.system -}}
-      {{- printf "'%s'" ( mustToRawJson .Values.hydra.config.secrets.system ) -}}
+      "{{- join "\",\"" .Values.hydra.config.secrets.system -}}"
     {{- else -}}
-      {{- fail "Expected .Values.hydra.config.secrets.system to be a list of strings" -}}
+      {{- fail "Expected hydra.config.secrets.system to be a list of strings" -}}
     {{- end -}}
   {{- else if .Values.demo -}}
-'["a-very-insecure-secret-for-checking-out-the-demo"]'
+      "a-very-insecure-secret-for-checking-out-the-demo"
   {{- end -}}
 {{- end -}}
 


### PR DESCRIPTION
Currently the helper `hydra.secrets.system` creates an output not compatible with Hydra and other Ory products accodingly to [these docs](https://www.ory.sh/docs/ecosystem/configuring/#stringnumeric-arrays).

Also in the docs mentioned above the paragraph "The whole csv string might be enclosed by square brackets." is wrong, because by adding the square brakets Hydra dosen't work and we get the error below.

Error on Hydra v1.10.3:
```
The configuration contains values or keys which are invalid:
secrets.system: <nil>
                ^-- expected array, but got null
```

## Example

Helm values:
```
hydra:
  config:
    secrets:
      system:
        - firstRandomSecret1234567890
        - secondRandomSecret1234567890
```

Current output:
`SECRETS_SYSTEM='["firstRandomSecret1234567890","secondRandomSecret1234567890"]'`

Fixed output:
`SECRETS_SYSTEM="firstRandomSecret1234567890","secondRandomSecret1234567890"`

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
      and signed the CLA.
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added necessary documentation within the code base (if
      appropriate).
