### PR TITLE
fix: Inject imagePullSecrets in hydra migrate job

### DIFF
--- a/helm/charts/hydra/templates/job-migration.yaml
+++ b/helm/charts/hydra/templates/job-migration.yaml
@@ -27,6 +27,10 @@ spec:
         {{- toYaml . | nindent 8 }}
     {{- end }}
     spec:
+    {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
       containers:
       - name: {{ .Chart.Name }}-automigrate
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"


### PR DESCRIPTION
Inject `imagePullSecrets` values into hydra automigrate job when registry authentication is needed to pull the image

## Related Issue or Design Document

Bug Fix: 
`imagePullSecrets` are not inject into hydra automigrate job, preventing hydra to be instanciated when authentication to the image registry is needed.

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
      and signed the CLA.
- [ ] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added necessary documentation within the code base (if
      appropriate).

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
