### PR TITLE
feat: Add support for overriding kratos deployment entrypoint (to allow sourcing DB credentials dynamically)

### DIFF
--- a/helm/charts/kratos/templates/deployment.yaml
+++ b/helm/charts/kratos/templates/deployment.yaml
@@ -93,14 +93,14 @@ spec:
           image: {{ include "kratos.image" . }}
           imagePullPolicy: {{ include "kratos.imagePullPolicy" . }}
           command:
-          {{ if not (empty .Values.deployment.overrideArgs.command) }}
-{{ toYaml .Values.deployment.overrideArgs.command | indent 12 }}
+          {{ if .Values.deployment.customCommand }}
+{{ tpl .Values.deployment.customCommand . | indent 12 }}
           {{ else }}
             - kratos
           {{ end }}
           args:
-          {{ if not (empty .Values.deployment.overrideArgs.args) }}
-{{ toYaml .Values.deployment.overrideArgs.args | indent 12 }}
+          {{ if .Values.deployment.customArgs }}
+{{ tpl .Values.deployment.customArgs . | indent 12 }}
           {{ else }}
             - serve
             - all

--- a/helm/charts/kratos/templates/deployment.yaml
+++ b/helm/charts/kratos/templates/deployment.yaml
@@ -93,8 +93,15 @@ spec:
           image: {{ include "kratos.image" . }}
           imagePullPolicy: {{ include "kratos.imagePullPolicy" . }}
           command:
+          {{ if not (empty .Values.deployment.overrideArgs.command) }}
+{{ toYaml .Values.deployment.overrideArgs.command | indent 12 }}
+          {{ else }}
             - kratos
+          {{ end }}
           args:
+          {{ if not (empty .Values.deployment.overrideArgs.args) }}
+{{ toYaml .Values.deployment.overrideArgs.args | indent 12 }}
+          {{ else }}
             - serve
             - all
             {{- if .Values.kratos.development }}
@@ -103,6 +110,7 @@ spec:
             - --config
             - /etc/config/kratos.yaml
             {{- if .Values.deployment.extraArgs }}
+          {{ end }}
 {{ toYaml .Values.deployment.extraArgs | indent 12 }}
             {{- end }}
           volumeMounts:

--- a/helm/charts/kratos/templates/job-migration.yaml
+++ b/helm/charts/kratos/templates/job-migration.yaml
@@ -43,8 +43,18 @@ spec:
       - name: {{ .Chart.Name }}-automigrate
         image: {{ include "kratos.image" . }}
         imagePullPolicy: {{ include "kratos.imagePullPolicy" . }}
+        {{ if .Values.job.customCommand }}
+        command:
+{{ tpl .Values.job.customCommand . | indent 10 }}
+        {{ else }}
         command: ["kratos"]
+        {{ end }}
+        {{ if .Values.job.customArgs }}
+        args:
+{{ tpl .Values.job.customArgs . | indent 10 }}
+        {{ else }}
         args: ["migrate", "sql", "-e", "--yes"]
+        {{ end }}
         env:
           - name: DSN
             valueFrom:

--- a/helm/charts/kratos/values.yaml
+++ b/helm/charts/kratos/values.yaml
@@ -185,6 +185,13 @@ deployment:
   # - --sqa-opt-out
   extraArgs: []
 
+  # Set these to override the entrypoint of the deployment container
+  # (e.g. to source dynamic secrets or export environment dynamic variables)
+  overrideArgs:
+    command: []
+    args: []
+
+
   # -- Array of extra envs to be passed to the deployment. Kubernetes format is expected
   # - name: FOO
   #   value: BAR

--- a/helm/charts/kratos/values.yaml
+++ b/helm/charts/kratos/values.yaml
@@ -187,9 +187,9 @@ deployment:
 
   # Set these to override the entrypoint of the deployment container
   # (e.g. to source dynamic secrets or export environment dynamic variables)
-  overrideArgs:
-    command: []
-    args: []
+  # This can be a multiline string with templating to be parsed as a YAML array
+  customCommand: ""
+  customArgs: ""
 
 
   # -- Array of extra envs to be passed to the deployment. Kubernetes format is expected
@@ -379,6 +379,12 @@ job:
       helm.sh/hook-delete-policy: "before-hook-creation"
     # -- The name of the service account to use. If not set and create is true, a name is generated using the fullname template
     name: ""
+
+  # Set these to override the entrypoint of the job container
+  # (e.g. to source dynamic secrets or export environment dynamic variables)
+  # This can be a multiline string with templating to be parsed as a YAML array
+  customCommand: ""
+  customArgs: ""
 
   spec:
     # -- Set job back off limit


### PR DESCRIPTION
Update kratos helm chart to allow overriding default entrypoint to support exporting environment variables using dynamic secrets.

The immediate use case is for getting a dynamic DB connection string issued by Hashicorp Vault, instead of a static kubernetes secret. 

## Checklist

- [ ] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
      and signed the CLA.
- [ ] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [ ] I have read the [security policy](../security/policy).
- [ ] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added necessary documentation within the code base (if
      appropriate).

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
