### PR TITLE
feat: Allow disabling securityContext

### DIFF
--- a/helm/charts/hydra-maester/templates/deployment.yaml
+++ b/helm/charts/hydra-maester/templates/deployment.yaml
@@ -54,8 +54,10 @@ spec:
             {{- toYaml .Values.deployment.resources | nindent 12 }}
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
+          {{- if .Values.deployment.securityContext }}
           securityContext:
             {{- toYaml .Values.deployment.securityContext | nindent 12 }}
+          {{- end }}
       serviceAccountName: {{ include "hydra-maester.fullname" . }}-account
       automountServiceAccountToken: {{ .Values.deployment.automountServiceAccountToken }}
       {{- if .Values.priorityClassName }}

--- a/helm/charts/hydra/templates/deployment.yaml
+++ b/helm/charts/hydra/templates/deployment.yaml
@@ -50,8 +50,10 @@ spec:
       containers:
         {{- if .Values.watcher.enabled }}
         - name: watcher
+          {{- if .Values.deployment.securityContext }}
           securityContext:
             {{- toYaml .Values.deployment.securityContext | nindent 12 }}
+          {{- end }}
           image: {{ .Values.watcher.image }}
           command:
             - /bin/bash
@@ -153,8 +155,10 @@ spec:
             {{- end }}
           resources:
             {{- toYaml .Values.deployment.resources | nindent 12 }}
+          {{- if .Values.deployment.securityContext }}
           securityContext:
             {{- toYaml .Values.deployment.securityContext | nindent 12 }}
+          {{- end }}
           lifecycle:
             {{- toYaml .Values.deployment.lifecycle | nindent 12 }}
         {{- if .Values.deployment.extraContainers }}

--- a/helm/charts/hydra/templates/job-migration.yaml
+++ b/helm/charts/hydra/templates/job-migration.yaml
@@ -49,8 +49,10 @@ spec:
         lifecycle:
 {{ tpl .Values.job.lifecycle . | indent 10 }}
         {{- end }}
+        {{- if .Values.deployment.securityContext }}
         securityContext:
           {{- toYaml .Values.deployment.securityContext | nindent 10 }}
+        {{- end }}
         {{- if .Values.deployment.extraVolumeMounts }}
         volumeMounts:
 {{ toYaml .Values.deployment.extraVolumeMounts | indent 10 }}

--- a/helm/charts/keto/templates/deployment.yaml
+++ b/helm/charts/keto/templates/deployment.yaml
@@ -58,8 +58,10 @@ spec:
       containers:
         {{- if .Values.watcher.enabled }}
         - name: watcher
+          {{- if .Values.securityContext }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
+          {{- end }}
           image: {{ .Values.watcher.image }}
           command:
             - /bin/bash
@@ -79,8 +81,10 @@ spec:
           {{- end }}
         {{- end }}
         - name: {{ .Chart.Name }}
+          {{- if .Values.securityContext }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
+          {{- end }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: [ "keto" ]

--- a/helm/charts/keto/templates/job-migration.yaml
+++ b/helm/charts/keto/templates/job-migration.yaml
@@ -63,8 +63,10 @@ spec:
           {{- with $extraEnv }}
             {{- toYaml . | nindent 10 }}
           {{- end }}
+        {{- if .Values.securityContext }}
         securityContext:
           {{- toYaml .Values.securityContext | nindent 10 }}
+        {{- end }}
       {{- if .Values.job.extraContainers }}
 {{ tpl .Values.job.extraContainers . | indent 6 }}
       {{- end }}

--- a/helm/charts/kratos-selfservice-ui-node/templates/deployment.yaml
+++ b/helm/charts/kratos-selfservice-ui-node/templates/deployment.yaml
@@ -81,8 +81,10 @@ spec:
               port: http
           resources:
             {{- toYaml .Values.deployment.resources | nindent 12 }}
+          {{- if .Values.securityContext }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
+          {{- end }}
       {{- with .Values.deployment.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/helm/charts/kratos/templates/deployment.yaml
+++ b/helm/charts/kratos/templates/deployment.yaml
@@ -69,8 +69,10 @@ spec:
       containers:
         {{- if .Values.watcher.enabled }}
         - name: watcher
+          {{- if .Values.securityContext }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
+          {{- end }}
           image: {{ .Values.watcher.image }}
           command:
             - /bin/bash
@@ -190,8 +192,10 @@ spec:
             {{- toYaml .Values.deployment.readinessProbe | nindent 12 }}
           resources:
             {{- toYaml $resources | nindent 12 }}  
+          {{- if .Values.securityContext }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
+          {{- end }}
         {{- if .Values.deployment.extraContainers }}
 {{ tpl .Values.deployment.extraContainers . | indent 8 }}
         {{- end }}

--- a/helm/charts/kratos/templates/job-migration.yaml
+++ b/helm/charts/kratos/templates/job-migration.yaml
@@ -55,8 +55,10 @@ spec:
         lifecycle:
 {{ tpl .Values.job.lifecycle . | indent 10 }}
       {{- end }}
+        {{- if .Values.securityContext }}
         securityContext:
           {{- toYaml .Values.securityContext | nindent 10 }}
+        {{- end }}
         {{- if .Values.deployment.extraVolumeMounts }}
         volumeMounts:
 {{ toYaml .Values.deployment.extraVolumeMounts | indent 10 }}

--- a/helm/charts/kratos/templates/statefulset-mail.yaml
+++ b/helm/charts/kratos/templates/statefulset-mail.yaml
@@ -95,8 +95,10 @@ spec:
             {{- end }}
           resources:
               {{- toYaml $resources | nindent 12 }}
+          {{- if .Values.securityContext }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
+          {{- end }}
         {{- if .Values.deployment.extraContainers }}
 {{ tpl .Values.deployment.extraContainers . | indent 8 }}
         {{- end }}

--- a/helm/charts/oathkeeper-maester/templates/deployment.yaml
+++ b/helm/charts/oathkeeper-maester/templates/deployment.yaml
@@ -67,8 +67,10 @@ spec:
             {{- toYaml .Values.deployment.resources | nindent 12 }}
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
+          {{- if .Values.deployment.securityContext }}
           securityContext:
             {{- toYaml .Values.deployment.securityContext | nindent 12 }}
+          {{- end }}
       serviceAccountName: {{ include "oathkeeper-maester.fullname" . }}-account
       automountServiceAccountToken: {{ .Values.deployment.automountServiceAccountToken }}
       dnsPolicy: ClusterFirst

--- a/helm/charts/oathkeeper/templates/deployment-controller.yaml
+++ b/helm/charts/oathkeeper/templates/deployment-controller.yaml
@@ -119,8 +119,10 @@ spec:
               port: http-api
           resources:
             {{- toYaml .Values.deployment.resources | nindent 12 }}
+          {{- if .Values.deployment.securityContext }}
           securityContext:
             {{- toYaml .Values.deployment.securityContext | nindent 12 }}
+          {{- end }}
         {{- if .Values.deployment.extraContainers }}
 {{ tpl .Values.deployment.extraContainers . | indent 8 }}
         {{- end }}

--- a/helm/charts/oathkeeper/templates/deployment-sidecar.yaml
+++ b/helm/charts/oathkeeper/templates/deployment-sidecar.yaml
@@ -56,8 +56,10 @@ spec:
             - |
               touch /etc/rules/access-rules.json
               chmod 666 /etc/rules/access-rules.json
+          {{- if .Values.deployment.securityContext }}
           securityContext:
             {{- toYaml .Values.deployment.securityContext | nindent 12 }}
+          {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
@@ -98,8 +100,10 @@ spec:
               port: http-api
           resources:
             {{- toYaml .Values.deployment.resources | nindent 12 }}
+          {{- if .Values.deployment.securityContext }}
           securityContext:
             {{- toYaml .Values.deployment.securityContext | nindent 12 }}
+          {{- end }}
         - name: {{ .Chart.Name }}-maester
           image: "{{ .Values.sidecar.image.repository }}:{{ .Values.sidecar.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
@@ -122,8 +126,10 @@ spec:
             - name: {{ include "oathkeeper.name" . }}-rules-volume
               mountPath: /etc/rules
               readOnly: false
+          {{- if .Values.deployment.securityContext }}
           securityContext:
             {{- toYaml .Values.deployment.securityContext | nindent 12 }}
+          {{- end }}
         {{- if .Values.deployment.extraContainers }}
 {{ tpl .Values.deployment.extraContainers . | indent 8 }}
         {{- end }}


### PR DESCRIPTION
Allows setting `securityContext.enabled: false` which omits the securityContext-setting for the containers. In some environment (e.g. OpenShift) you don't want to set them (e.g. they are set automatically).

## Related Issue or Design Document

https://github.com/ory/k8s/issues/421

## Checklist

- [X] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
      and signed the CLA.
- [X] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [X] I have read the [security policy](../security/policy).
- [X] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [X] I have added necessary documentation within the code base (if
      appropriate).
