### PR TITLE
Fix reference to Oathkeeper acces-rule configmap

### DIFF
--- a/helm/charts/oathkeeper-maester/templates/_helpers.tpl
+++ b/helm/charts/oathkeeper-maester/templates/_helpers.tpl
@@ -49,9 +49,9 @@ Get Oathkeeper rules configmap
 */}}
 {{- define "oathkeeper-maester.getCM" -}}
 {{- if .Values.oathkeeperFullnameOverride -}}
-{{- printf "%s-rules" .Values.oathkeeperFullnameOverride | trimSuffix "-" -}}
+{{- printf "%s-oathkeeper-rules" .Values.oathkeeperFullnameOverride | trimSuffix "-" -}}
 {{- else -}}
 {{- $fullName := include "oathkeeper-maester.fullname" . -}}
-{{- printf "%s-rules" $fullName | replace "-oathkeeper-maester" "" -}}
+{{- printf "%s-oathkeeper-rules" $fullName | replace "-oathkeeper-maester" "" -}}
 {{- end -}}
 {{- end -}}


### PR DESCRIPTION
Oathkeeper maester access-rule Configmap name was not lining up with the name generated by the Oathkeeper chart, hence it was not actually updating the access rule configurations

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
      and signed the CLA.
- [x] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added necessary documentation within the code base (if
      appropriate).
