### PR TITLE
fix(hydra): removes duplicated volumeMounts yaml int automigrate init container

### DIFF
--- a/helm/charts/hydra/templates/deployment.yaml
+++ b/helm/charts/hydra/templates/deployment.yaml
@@ -189,13 +189,6 @@ spec:
             {{- with .Values.deployment.extraEnv }}
               {{- toYaml . | nindent 12 }}
             {{- end }}
-          volumeMounts:
-            - name: {{ include "hydra.name" . }}-config-volume
-              mountPath: /etc/config
-              readOnly: true
-            {{- if .Values.deployment.extraVolumeMounts }}
-              {{- toYaml .Values.deployment.extraVolumeMounts | nindent 14 }}
-           {{- end }}
       {{- end }}
       {{- if .Values.deployment.extraInitContainers }}
         {{- tpl .Values.deployment.extraInitContainers . | nindent 8 }}


### PR DESCRIPTION
This fixes duplicated volumeMounts in the hydra migrate init container which causes the install to fail when

```
automigration:
        enabled: true
        type: initContainer
```

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md) and signed the CLA.
- [ ] I have referenced an issue containing the design document if my change introduces a new feature.
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security vulnerability. 
      If this pull request addresses a security vulnerability, 
      I confirm that I got green light (please contact [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push the changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation within the code base (if appropriate).
