### PR TITLE
fix: use the correct values naming within hydra-maester for consistency 

### DIFF
--- a/helm/charts/hydra-maester/templates/deployment.yaml
+++ b/helm/charts/hydra-maester/templates/deployment.yaml
@@ -22,7 +22,7 @@ spec:
         {{- with .Values.deployment.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-      {{- with .Values.annotations }}
+      {{- with .Values.deployment.annotations }}
       annotations:
         {{- toYaml . | nindent 8 }}
       {{- end }}


### PR DESCRIPTION
The use of `annotation` within `hydra-maester` is inconsistent with the other Ory Helm Charts, as well as it's own documentation. 

The `hydra-maester` documentation specified `deployment.annotations` already, and the other charts use the same format. 

```
BREAKING CHANGES: This patch changes the behavior of configuration item `annotation`. To keep the existing
behavior please do `deployment.annotation`.
```

## Checklist


- [X] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md) and signed the CLA.
- [ ] I have referenced an issue containing the design document if my change introduces a new feature.
- [X] I have read the [security policy](../security/policy).
- [X] I confirm that this pull request does not address a security vulnerability. 
      If this pull request addresses a security vulnerability, 
      I confirm that I got green light (please contact [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push the changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [X] I have added necessary documentation within the code base (if appropriate).
