### PR TITLE
Add default emailTemplates

### DIFF
--- a/helm/charts/kratos/README.md
+++ b/helm/charts/kratos/README.md
@@ -1,6 +1,6 @@
 # kratos
 
-![Version: 0.24.5](https://img.shields.io/badge/Version-0.24.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.10.1](https://img.shields.io/badge/AppVersion-v0.10.1-informational?style=flat-square)
+![Version: 0.25.0](https://img.shields.io/badge/Version-0.25.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.10.1](https://img.shields.io/badge/AppVersion-v0.10.1-informational?style=flat-square)
 
 A ORY Kratos Helm chart for Kubernetes
 
@@ -18,11 +18,12 @@ A ORY Kratos Helm chart for Kubernetes
 | deployment.extraArgs | list | `[]` | Array of extra arguments to be passed down to the deployment. Kubernetes args format is expected - --foo - --sqa-opt-out |
 | deployment.extraContainers | object | `{}` | If you want to add extra sidecar containers. |
 | deployment.extraEnv | list | `[]` | Array of extra envs to be passed to the deployment. Kubernetes format is expected - name: FOO   value: BAR |
+| deployment.extraInitContainers | object | `{}` | If you want to add extra init containers. These are processed before the migration init container. |
 | deployment.extraVolumes | list | `[]` | If you want to mount external volume For example, mount a secret containing Certificate root CA to verify database TLS connection. |
 | deployment.livenessProbe | object | `{"failureThreshold":5,"initialDelaySeconds":30,"periodSeconds":10}` | Configure the livenessProbe parameters |
 | deployment.nodeSelector | object | `{}` | Node labels for pod assignment. |
 | deployment.readinessProbe | object | `{"failureThreshold":5,"initialDelaySeconds":30,"periodSeconds":10}` | Configure the readinessProbe parameters |
-| deployment.serviceAccount | object | `{"annotations":{},"create":true,"name":""}` | The secret specified here will be used to load environment variables with envFrom. This allows arbitrary environment variables to be provided to the application which is useful for sensitive values which should not be in a configMap. This secret is not created by the helm chart and must already exist in the namespace. https://kubernetes.io/docs/tasks/inject-data-application/distribute-credentials-secure/#configure-all-key-value-pairs-in-a-secret-as-container-environment-variables environmentSecretsName: -- Specify the serviceAccountName value. In some situations it is needed to provide specific permissions to Kratos deployments. Like for example installing Kratos on a cluster with a PosSecurityPolicy and Istio. Uncomment if it is needed to provide a ServiceAccount for the Kratos deployment. |
+| deployment.serviceAccount | object | `{"annotations":{},"create":true,"name":""}` | Specify the serviceAccountName value. In some situations it is needed to provide specific permissions to Kratos deployments. Like for example installing Kratos on a cluster with a PosSecurityPolicy and Istio. Uncomment if it is needed to provide a ServiceAccount for the Kratos deployment. |
 | deployment.serviceAccount.annotations | object | `{}` | Annotations to add to the service account |
 | deployment.serviceAccount.create | bool | `true` | Specifies whether a service account should be created |
 | deployment.serviceAccount.name | string | `""` | The name of the service account to use. If not set and create is true, a name is generated using the fullname template |
@@ -60,21 +61,22 @@ A ORY Kratos Helm chart for Kubernetes
 | job.shareProcessNamespace | bool | `false` | Set sharing process namespace |
 | job.spec.backoffLimit | int | `10` | Set job back off limit |
 | kratos.automigration | object | `{"enabled":false,"type":"job"}` | Enables database migration |
-| kratos.automigration.type | string | `"job"` | Configure the way to execute database migration. Possible values: job, initContainer When set to job, the migration will be executed as a job on release or upgrade. When set to initContainer, the migration will be executed when kratos pod is created Defaults to job   |
-| kratos.config | object | `{"courier":{"smtp":{}},"secrets":{},"serve":{"admin":{"port":4434},"public":{"port":4433}}}` | You can customize the emails kratos is sending (also uncomment config.courier.template_override_path below)  Note: If you are setting config.courier.template_override_path you need to supply overrides for all templates.        It is currently not possible to overrides only selected methods.  emailTemplates:    recovery:      valid:        subject: Recover access to your account        body: |-          Hi, please recover access to your account by clicking the following link:          <a href="{{ .RecoveryURL }}">{{ .RecoveryURL }}</a>        plainBody: Hi, please recover access to your account by clicking the following link: {{ .RecoveryURL }}      invalid:        subject: Account access attempted        body: |-          Hi, you (or someone else) entered this email address when trying to recover access to an account.          However, this email address is not on our database of registered users and therefore the attempt has failed. If this was you, check if you signed up using a different address. If this was not you, please ignore this email.        plainBody: Hi, you (or someone else) entered this email address when trying to recover access to an account.    verification:      valid:        subject: Please verify your email address        body: |-          Hi, please verify your account by clicking the following link:          <a href="{{ .VerificationURL }}">{{ .VerificationURL }}</a>        plainBody: Hi, please verify your account by clicking the following link: {{ .VerificationURL }}      invalid:        subject:        body:        plainBody: |
+| kratos.automigration.type | string | `"job"` | Configure the way to execute database migration. Possible values: job, initContainer When set to job, the migration will be executed as a job on release or upgrade. When set to initContainer, the migration will be executed when kratos pod is created Defaults to job |
+| kratos.config.courier.smtp | object | `{}` |  |
+| kratos.config.secrets | object | `{}` |  |
+| kratos.config.serve.admin.port | int | `4434` |  |
+| kratos.config.serve.public.port | int | `4433` |  |
 | kratos.development | bool | `false` |  |
+| kratos.emailTemplates | object | `{"recovery":{"invalid":{"body":"Hi, you (or someone else) entered this email address when trying to recover access to an account.\n\nHowever, this email address is not on our database of registered users and therefore the attempt has failed.\nIf this was you, check if you signed up using a different address. If this was not you, please ignore this email.","plainBody":"Hi, you (or someone else) entered this email address when trying to recover access to an account.","subject":"Account access attempted"},"valid":{"body":"Hi, please recover access to your account by clicking the following link:\n\n<a href=\"{{ .RecoveryURL }}\">{{ .RecoveryURL }}</a>","plainBody":"Hi, please recover access to your account by clicking the following link: {{ .RecoveryURL }}","subject":"Recover access to your account"}},"verification":{"invalid":{"body":null,"plainBody":null,"subject":null},"valid":{"body":"Hi, please verify your account by clicking the following link:\n\n<a href=\"{{ .VerificationURL }}\">{{ .VerificationURL }}</a>","plainBody":"Hi, please verify your account by clicking the following link: {{ .VerificationURL }}","subject":"Please verify your email address"}}}` | You can customize the emails kratos is sending (also uncomment config.courier.template_override_path below) Note: If you are setting config.courier.template_override_path you need to supply overrides for all templates. It is currently not possible to overrides only selected methods. |
 | kratos.identitySchemas | object | `{}` | You can add multiple identity schemas here |
 | nameOverride | string | `""` |  |
 | nodeSelector | object | `{}` | Node labels for pod assignment. |
 | pdb | object | `{"enabled":false,"spec":{"minAvailable":1}}` | PodDistributionBudget configuration |
-| replicaCount | int | `1` |  |
+| replicaCount | int | `1` | Number of replicas in deployment |
 | secret.enabled | bool | `true` | switch to false to prevent creating the secret |
 | secret.hashSumEnabled | bool | `true` | switch to false to prevent checksum annotations being maintained and propogated to the pods |
 | secret.nameOverride | string | `""` | Provide custom name of existing secret, or custom name of secret to be created |
-| secret.secretAnnotations."helm.sh/hook" | string | `"pre-install, pre-upgrade"` |  |
-| secret.secretAnnotations."helm.sh/hook-delete-policy" | string | `"before-hook-creation"` |  |
-| secret.secretAnnotations."helm.sh/hook-weight" | string | `"0"` |  |
-| secret.secretAnnotations."helm.sh/resource-policy" | string | `"keep"` |  |
+| secret.secretAnnotations | object | `{"helm.sh/hook":"pre-install, pre-upgrade","helm.sh/hook-delete-policy":"before-hook-creation","helm.sh/hook-weight":"0","helm.sh/resource-policy":"keep"}` | Annotations to be added to secret. Annotations are added only when secret is being created. Existing secret will not be modified. |
 | securityContext.allowPrivilegeEscalation | bool | `false` |  |
 | securityContext.capabilities.drop[0] | string | `"ALL"` |  |
 | securityContext.privileged | bool | `false` |  |
@@ -117,4 +119,4 @@ A ORY Kratos Helm chart for Kubernetes
 | watcher | object | `{"enabled":false,"image":"oryd/k8s-toolbox:0.0.4","mountFile":""}` | Configuration of the watcher sidecar |
 
 ----------------------------------------------
-Autogenerated from chart metadata using [helm-docs v1.5.0](https://github.com/norwoodj/helm-docs/releases/v1.5.0)
+Autogenerated from chart metadata using [helm-docs v1.11.0](https://github.com/norwoodj/helm-docs/releases/v1.11.0)

--- a/helm/charts/kratos/values.yaml
+++ b/helm/charts/kratos/values.yaml
@@ -112,7 +112,7 @@ kratos:
     # -- Configure the way to execute database migration. Possible values: job, initContainer
     # When set to job, the migration will be executed as a job on release or upgrade.
     # When set to initContainer, the migration will be executed when kratos pod is created
-    # Defaults to job  
+    # Defaults to job
     type: job
 
   # -- You can add multiple identity schemas here
@@ -128,37 +128,40 @@ kratos:
   #    }
 
   # -- You can customize the emails kratos is sending (also uncomment config.courier.template_override_path below)
-  #  Note: If you are setting config.courier.template_override_path you need to supply overrides for all templates.
-  #        It is currently not possible to overrides only selected methods.
-  #
-  #  emailTemplates:
-  #    recovery:
-  #      valid:
-  #        subject: Recover access to your account
-  #        body: |-
-  #          Hi, please recover access to your account by clicking the following link:
-  #
-  #          <a href="{{ .RecoveryURL }}">{{ .RecoveryURL }}</a>
-  #        plainBody: Hi, please recover access to your account by clicking the following link: {{ .RecoveryURL }}
-  #      invalid:
-  #        subject: Account access attempted
-  #        body: |-
-  #          Hi, you (or someone else) entered this email address when trying to recover access to an account.
-  #
-  #          However, this email address is not on our database of registered users and therefore the attempt has failed. If this was you, check if you signed up using a different address. If this was not you, please ignore this email.
-  #        plainBody: Hi, you (or someone else) entered this email address when trying to recover access to an account.
-  #    verification:
-  #      valid:
-  #        subject: Please verify your email address
-  #        body: |-
-  #          Hi, please verify your account by clicking the following link:
-  #
-  #          <a href="{{ .VerificationURL }}">{{ .VerificationURL }}</a>
-  #        plainBody: Hi, please verify your account by clicking the following link: {{ .VerificationURL }}
-  #      invalid:
-  #        subject:
-  #        body:
-  #        plainBody:
+  # Note: If you are setting config.courier.template_override_path you need to supply overrides for all templates.
+  # It is currently not possible to overrides only selected methods.
+  emailTemplates:
+    recovery:
+      valid:
+        subject: Recover access to your account
+        body: |-
+          Hi, please recover access to your account by clicking the following link:
+
+          <a href="{{ .RecoveryURL }}">{{ .RecoveryURL }}</a>
+        plainBody: |-
+          Hi, please recover access to your account by clicking the following link: {{ .RecoveryURL }}
+      invalid:
+        subject: Account access attempted
+        body: |-
+          Hi, you (or someone else) entered this email address when trying to recover access to an account.
+
+          However, this email address is not on our database of registered users and therefore the attempt has failed.
+          If this was you, check if you signed up using a different address. If this was not you, please ignore this email.
+        plainBody: |-
+          Hi, you (or someone else) entered this email address when trying to recover access to an account.
+    verification:
+      valid:
+        subject: Please verify your email address
+        body: |-
+          Hi, please verify your account by clicking the following link:
+
+          <a href="{{ .VerificationURL }}">{{ .VerificationURL }}</a>
+        plainBody: |-
+          Hi, please verify your account by clicking the following link: {{ .VerificationURL }}
+      invalid:
+        subject:
+        body:
+        plainBody:
 
   config:
     courier:


### PR DESCRIPTION
See https://github.com/ory/k8s/issues/490:

> The kratos.emailTemplates key is not properly rendered by helm docs, it doesn't show up in the README.md table in the first column, but in the last one under kratos.config.
