### PR TITLE
feat: expose Oathkeeper check port

### DIFF
--- a/helm/charts/oathkeeper/templates/deployment-controller.yaml
+++ b/helm/charts/oathkeeper/templates/deployment-controller.yaml
@@ -112,6 +112,11 @@ spec:
             - name: http-metrics
               protocol: TCP
               containerPort: {{ .Values.oathkeeper.config.serve.prometheus.port }}
+            {{- if .Values.service.check.enabled }}
+            - name: grpc-check
+              protocol: TCP
+              containerPort: {{ .Values.oathkeeper.config.serve.check.port }}
+            {{- end }}
           livenessProbe:
             httpGet:
               path: /health/alive

--- a/helm/charts/oathkeeper/templates/deployment-sidecar.yaml
+++ b/helm/charts/oathkeeper/templates/deployment-sidecar.yaml
@@ -91,6 +91,11 @@ spec:
             - name: http-metrics
               protocol: TCP
               containerPort: {{ .Values.oathkeeper.config.serve.prometheus.port }}
+            {{- if .Values.service.check.enabled }}
+            - name: grpc-check
+              protocol: TCP
+              containerPort: {{ .Values.oathkeeper.config.serve.check.port }}
+            {{- end }}
           livenessProbe:
             httpGet:
               path: /health/alive

--- a/helm/charts/oathkeeper/values.yaml
+++ b/helm/charts/oathkeeper/values.yaml
@@ -74,6 +74,25 @@ service:
     # e.g.  app: oathkeeper
     labels: {}
 
+  # -- Configures the Kubernetes service for the check port.
+  check:
+    # -- En-/disable the service
+    enabled: false
+    # -- The service type
+    type: ClusterIP
+    # -- The service port
+    port: 4457
+    # -- The service port name. Useful to set a custom service port name if it must follow a scheme (e.g. Istio)
+    name: grpc
+    # -- If you do want to specify annotations, uncomment the following
+    # lines, adjust them as necessary, and remove the curly braces after 'annotations:'.
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+    annotations: {}
+    # -- If you do want to specify additional labels, uncomment the following lines, adjust them as necessary, and remove the curly braces after 'labels:'.
+    # e.g.  app: oathkeeper
+    labels: {}
+
   # -- Configures the Kubernetes service for the metrics port.
   metrics:
     # -- En-/disable the service
@@ -152,6 +171,8 @@ oathkeeper:
         port: 4455
       api:
         port: 4456
+      check:
+        port: 4457
       prometheus:
         port: 9000
   # -- If set, uses the given JSON Web Key Set as the signing key for the ID Token Mutator.


### PR DESCRIPTION
This PR adds the option to configure the gRPC Check service for Oathkeeper.

Blocked by https://github.com/ory/oathkeeper/pull/993