### PR TITLE
feat: allow custom commands and args on migration containers

### DIFF
--- a/hacks/values/hydra.yaml
+++ b/hacks/values/hydra.yaml
@@ -8,6 +8,8 @@ hydra:
   automigration:
     enabled: true
     # type: initContainer
+    customCommand:
+      - hydra
   dangerousForceHttp: true
   config:
     dsn: "postgres://postgres:ory@postgresql.default.svc.cluster.local/ory?sslmode=disable&max_conn_lifetime=10s"

--- a/hacks/values/keto.yaml
+++ b/hacks/values/keto.yaml
@@ -2,6 +2,8 @@
 keto:
   automigration: 
     enabled: true
+    customCommand:
+      - keto
   config:
     dsn: "postgres://postgres:ory@postgresql.default.svc.cluster.local/ory?sslmode=disable&max_conn_lifetime=10s"
 ingress:

--- a/hacks/values/kratos.yaml
+++ b/hacks/values/kratos.yaml
@@ -5,7 +5,7 @@ kratos:
   automigration:
     enabled: true
     customCommand:
-      - hydra
+      - kratos
     customArgs:
       - "migrate"
       - "sql"

--- a/hacks/values/kratos.yaml
+++ b/hacks/values/kratos.yaml
@@ -3,7 +3,16 @@ autoscaling:
   enabled: false
 kratos:
   automigration:
-      enabled: true
+    enabled: true
+    customCommand:
+      - hydra
+    customArgs:
+      - "migrate"
+      - "sql"
+      - "-e"
+      - "--yes"
+      - "--config"
+      - "/etc/config/kratos.yaml"
   identitySchemas:
     "identity.default.schema.json": |
       {

--- a/helm/charts/hydra/templates/deployment.yaml
+++ b/helm/charts/hydra/templates/deployment.yaml
@@ -153,8 +153,16 @@ spec:
         - name: {{ .Chart.Name }}-automigrate
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- if .Values.hydra.automigration.customCommand }}
+          command: {{- toYaml .Values.hydra.automigration.customCommand | nindent 12 }}
+          {{- else }}
           command: ["hydra"]
+          {{- end }}
+          {{- if .Values.hydra.automigration.customArgs }}
+          args: {{- toYaml .Values.hydra.automigration.customArgs | nindent 12 }}
+          {{- else }}
           args: ["migrate", "sql", "-e", "--yes", "--config", "/etc/config/hydra.yaml"]
+          {{- end }}
           volumeMounts:
             - name: {{ include "hydra.name" . }}-config-volume
               mountPath: /etc/config

--- a/helm/charts/hydra/templates/job-migration.yaml
+++ b/helm/charts/hydra/templates/job-migration.yaml
@@ -49,8 +49,16 @@ spec:
       - name: {{ .Chart.Name }}-automigrate
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
+        {{- if .Values.hydra.automigration.customCommand }}
+        command: {{- toYaml .Values.hydra.automigration.customCommand | nindent 10 }}
+        {{- else }}
         command: ["hydra"]
+        {{- end }}
+        {{- if .Values.hydra.automigration.customArgs }}
+        args: {{- toYaml .Values.hydra.automigration.customArgs | nindent 10 }}
+        {{- else }}
         args: ["migrate", "sql", "-e", "--yes", "--config", "/etc/config/hydra.yaml"]
+        {{- end }}
         env:
           - name: DSN
             valueFrom:

--- a/helm/charts/hydra/values.yaml
+++ b/helm/charts/hydra/values.yaml
@@ -150,6 +150,14 @@ hydra:
     # When set to initContainer, the migration will be executed when kratos pod is created
     # Defaults to job  
     type: job
+    # -- Ability to override the entrypoint of the automigration container
+    # (e.g. to source dynamic secrets or export environment dynamic variables)
+    customCommand: []
+    #   - sleep 5;
+    #   - kratos
+    customArgs: []
+
+
   dangerousForceHttp: false
   dangerousAllowInsecureRedirectUrls: false
 

--- a/helm/charts/hydra/values.yaml
+++ b/helm/charts/hydra/values.yaml
@@ -153,7 +153,9 @@ hydra:
     # -- Ability to override the entrypoint of the automigration container
     # (e.g. to source dynamic secrets or export environment dynamic variables)
     customCommand: []
-    #   - sleep 5;
+    # -- Ability to override arguments of the entrypoint. Can be used in-depended of customCommand  
+    # eg:
+    # - sleep 5;
     #   - kratos
     customArgs: []
 

--- a/helm/charts/keto/templates/deployment.yaml
+++ b/helm/charts/keto/templates/deployment.yaml
@@ -65,8 +65,16 @@ spec:
         - name: {{ .Chart.Name }}-automigrate
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          command: [ "keto" ]
+          {{- if .Values.keto.automigration.customCommand }}
+          command: {{- toYaml .Values.keto.automigration.customCommand | nindent 12 }}
+          {{- else }}
+          command: ["keto"]
+          {{- end }}
+          {{- if .Values.keto.automigration.customArgs }}
+          args: {{- toYaml .Values.keto.automigration.customArgs | nindent 12 }}
+          {{- else }}
           args: [ "migrate", "up", "-y", "--config", "/etc/config/keto.yaml" ]
+          {{- end }}
           volumeMounts:
             - name: {{ include "keto.name" . }}-config-volume
               mountPath: /etc/config

--- a/helm/charts/keto/templates/job-migration.yaml
+++ b/helm/charts/keto/templates/job-migration.yaml
@@ -50,8 +50,16 @@ spec:
       - name: {{ .Chart.Name }}-automigrate
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
-        command: [ "keto" ]
+        {{- if .Values.keto.automigration.customCommand }}
+        command: {{- toYaml .Values.keto.automigration.customCommand | nindent 10 }}
+        {{- else }}
+        command: ["keto"]
+        {{- end }}
+        {{- if .Values.keto.automigration.customArgs }}
+        args: {{- toYaml .Values.keto.automigration.customArgs | nindent 10 }}
+        {{- else }}
         args: [ "migrate", "up", "-y", "--config", "/etc/config/keto.yaml" ]
+        {{- end }}
         {{- if .Values.job.lifecycle }}
 {{ tpl .Values.job.lifecycle . | indent 8 }}
         {{- end }}

--- a/helm/charts/keto/values.yaml
+++ b/helm/charts/keto/values.yaml
@@ -185,7 +185,9 @@ keto:
     # -- Ability to override the entrypoint of the automigration container
     # (e.g. to source dynamic secrets or export environment dynamic variables)
     customCommand: []
-    #   - sleep 5;
+    # -- Ability to override arguments of the entrypoint. Can be used in-depended of customCommand 
+    # eg:
+    # - sleep 5;
     #   - keto
     customArgs: []
   # -- Direct keto config. Full documentation can be found in https://www.ory.sh/keto/docs/reference/configuration

--- a/helm/charts/keto/values.yaml
+++ b/helm/charts/keto/values.yaml
@@ -182,6 +182,12 @@ keto:
     # When set to initContainer, the migration will be executed when kratos pod is created
     # Defaults to job  
     type: job
+    # -- Ability to override the entrypoint of the automigration container
+    # (e.g. to source dynamic secrets or export environment dynamic variables)
+    customCommand: []
+    #   - sleep 5;
+    #   - keto
+    customArgs: []
   # -- Direct keto config. Full documentation can be found in https://www.ory.sh/keto/docs/reference/configuration
   config:
     serve:

--- a/helm/charts/kratos/templates/deployment-kratos.yaml
+++ b/helm/charts/kratos/templates/deployment-kratos.yaml
@@ -56,8 +56,16 @@ spec:
         - name: {{ .Chart.Name }}-automigrate
           image: {{ include "kratos.image" . }}
           imagePullPolicy: {{ include "kratos.imagePullPolicy" . }}
+          {{- if .Values.kratos.automigration.customCommand }}
+          command: {{- toYaml .Values.kratos.automigration.customCommand | nindent 12 }}
+          {{- else }}
           command: ["kratos"]
-          args: ["migrate", "sql", "-e", "--yes"]
+          {{- end }}
+          {{- if .Values.kratos.automigration.customArgs }}
+          args: {{- toYaml .Values.kratos.automigration.customArgs | nindent 12 }}
+          {{- else }}
+          args: ["migrate", "sql", "-e", "--yes", "--config", "/etc/config/kratos.yaml"]
+          {{- end }}
           volumeMounts:
             - name: {{ include "kratos.name" . }}-config-volume
               mountPath: /etc/config

--- a/helm/charts/kratos/templates/job-migration.yaml
+++ b/helm/charts/kratos/templates/job-migration.yaml
@@ -51,8 +51,16 @@ spec:
       - name: {{ .Chart.Name }}-automigrate
         image: {{ include "kratos.image" . }}
         imagePullPolicy: {{ include "kratos.imagePullPolicy" . }}
+        {{- if .Values.kratos.automigration.customCommand }}
+        command: {{- toYaml .Values.kratos.automigration.customCommand | nindent 10 }}
+        {{- else }}
         command: ["kratos"]
+        {{- end }}
+        {{- if .Values.kratos.automigration.customArgs }}
+        args: {{- toYaml .Values.kratos.automigration.customArgs | nindent 10 }}
+        {{- else }}
         args: ["migrate", "sql", "-e", "--yes", "--config", "/etc/config/kratos.yaml"]
+        {{- end }}
         env:
           - name: DSN
             valueFrom:

--- a/helm/charts/kratos/values.yaml
+++ b/helm/charts/kratos/values.yaml
@@ -117,7 +117,9 @@ kratos:
     # -- Ability to override the entrypoint of the automigration container
     # (e.g. to source dynamic secrets or export environment dynamic variables)
     customCommand: []
-    #   - sleep 5;
+    # -- Ability to override arguments of the entrypoint. Can be used in-depended of customCommand 
+    # eg:
+    # - sleep 5;
     #   - kratos
     customArgs: []
 

--- a/helm/charts/kratos/values.yaml
+++ b/helm/charts/kratos/values.yaml
@@ -114,6 +114,12 @@ kratos:
     # When set to initContainer, the migration will be executed when kratos pod is created
     # Defaults to job  
     type: job
+    # -- Ability to override the entrypoint of the automigration container
+    # (e.g. to source dynamic secrets or export environment dynamic variables)
+    customCommand: []
+    #   - sleep 5;
+    #   - kratos
+    customArgs: []
 
   # -- You can add multiple identity schemas here
   identitySchemas: {}


### PR DESCRIPTION
**Note**: Replaces #419, which appears to be inactive/stale. 

Allow the ability to pass through custom commands & args into the migration container. 

For our use case, we run the GCP cloud-sql-proxy sidecar containers, the migrations fail to run as they sometimes start before the proxy has started. This change allows us to add a `sleep` (or a `wait-for-it` script) to the migration command so that it waits for the sql proxy to be available. 

## Checklist

- [X] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md) and signed the CLA.
- [ ] I have referenced an issue containing the design document if my change introduces a new feature. **N/A**
- [X] I have read the [security policy](../security/policy).
- [X] I confirm that this pull request does not address a security vulnerability. 
      If this pull request addresses a security vulnerability, 
      I confirm that I got green light (please contact [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push the changes.
- [ ] I have added tests that prove my fix is effective or that my feature works. **N/A** - Tested via `helm template` and `helm install`
- [X] I have added necessary documentation within the code base (if appropriate).
