### PR TITLE
chore: hydra DSN is empty, maester in singleNamespaceMode with Role

### DIFF
--- a/docs/helm/hydra.md
+++ b/docs/helm/hydra.md
@@ -292,6 +292,31 @@ $ hydra token client \
     --client-secret secret
 ```
 
+### Set up DSN variable on runtime
+
+If you use need to construct DSN environment variable on the fly, you can leave
+`hydra.config.dsn` empty and provide custom DSN variable via `extraEnv`, e.g.:
+
+```yaml
+deployment:
+  extraEnv:
+  - name: DB_USER
+    valueFrom:
+      secretKeyRef:
+        name: hydra.postgres-hydra.credentials.postgresql.acid.zalan.do
+        key: username
+  - name: DB_PASSWORD
+    valueFrom:
+      secretKeyRef:
+        name: hydra.postgres-hydra.credentials.postgresql.acid.zalan.do
+        key: password
+  - name: DSN
+    value: postgres://$(DB_USER):$(DB_PASSWORD)@postgres-hydra:5432/hydra
+```
+
+In such case you don't need to take care about `hydra.config.dsn` value,
+when database was updated/recreated (in case with dynamic environments, gitops approach etc).
+
 ### Hydra Maester
 
 This chart includes a helper chart in the form of

--- a/helm/charts/hydra-maester/templates/rbac.yaml
+++ b/helm/charts/hydra-maester/templates/rbac.yaml
@@ -4,6 +4,7 @@ kind: ServiceAccount
 metadata:
   name: {{ include "hydra-maester.fullname" . }}-account
   namespace:  {{ .Release.Namespace }}
+{{- if not .Values.singleNamespaceMode }}
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
@@ -29,21 +30,25 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: {{ include "hydra-maester.fullname" . }}-role
+{{- end }}
 ---
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: {{ include "hydra-maester.fullname" . }}-role-{{ .Release.Namespace }}
+  name: {{ include "hydra-maester.fullname" . }}-role
   namespace:  {{ .Release.Namespace }}
 rules:
   - apiGroups: [""]
     resources: ["secrets"]
     verbs: ["get", "list", "watch", "create"]
+  - apiGroups: ["hydra.ory.sh"]
+    resources: ["oauth2clients", "oauth2clients/status"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: {{ include "hydra-maester.fullname" . }}-role-binding-{{ .Release.Namespace }}
+  name: {{ include "hydra-maester.fullname" . }}-role-binding
   namespace:  {{ .Release.Namespace }}
 subjects:
   - kind: ServiceAccount
@@ -52,7 +57,7 @@ subjects:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: {{ include "hydra-maester.fullname" . }}-role-{{ .Release.Namespace }}
+  name: {{ include "hydra-maester.fullname" . }}-role
 
 {{- $name := include "hydra-maester.fullname" . -}}
 {{- $namespace := .Release.Namespace -}}
@@ -61,7 +66,7 @@ roleRef:
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: {{ $name }}-role-{{ . }}
+  name: {{ $name }}-role
   namespace:  {{ . }}
 rules:
   - apiGroups: [""]
@@ -71,7 +76,7 @@ rules:
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: {{ $name }}-role-binding-{{ . }}
+  name: {{ $name }}-role-binding
   namespace:  {{ . }}
 subjects:
   - kind: ServiceAccount
@@ -80,5 +85,5 @@ subjects:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: {{ $name }}-role-{{ . }}
+  name: {{ $name }}-role
 {{- end }}

--- a/helm/charts/hydra/templates/deployment.yaml
+++ b/helm/charts/hydra/templates/deployment.yaml
@@ -119,11 +119,13 @@ spec:
             - name: URLS_SELF_ISSUER
               value: {{ $issuer | quote }}
             {{- end }}
+            {{- if not (empty ( include "hydra.dsn" . )) }}
             - name: DSN
               valueFrom:
                 secretKeyRef:
                   name: {{ include "hydra.secretname" . }}
                   key: dsn
+            {{- end }}
             - name: SECRETS_SYSTEM
               valueFrom:
                 secretKeyRef:
@@ -171,11 +173,13 @@ spec:
             {{- toYaml . | nindent 12 }}
           {{- end }}
           env:
+            {{- if not (empty ( include "hydra.dsn" . )) }}
             - name: DSN
               valueFrom:
                 secretKeyRef:
                   name: {{ include "hydra.secretname" . }}
                   key: dsn
+            {{- end }}
             {{- with .Values.deployment.extraEnv }}
               {{- toYaml . | nindent 12 }}
             {{- end }}

--- a/helm/charts/hydra/templates/job-migration.yaml
+++ b/helm/charts/hydra/templates/job-migration.yaml
@@ -20,7 +20,7 @@ metadata:
     {{- end }}
 spec:
   template:
-    metadata: 
+    metadata:
       annotations:
         {{- with .Values.job.annotations }}
           {{- toYaml . | nindent 8 }}
@@ -57,11 +57,13 @@ spec:
         args: ["migrate", "sql", "-e", "--yes", "--config", "/etc/config/hydra.yaml"]
         {{- end }}
         env:
+        {{- if not (empty ( include "hydra.dsn" . )) }}
           - name: DSN
             valueFrom:
               secretKeyRef:
                 name: {{ include "hydra.secretname" . }}
                 key: dsn
+        {{- end }}
         {{- with .Values.deployment.extraEnv }}
           {{- toYaml . | nindent 10 }}
         {{- end }}


### PR DESCRIPTION
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.

This text will be included in the changelog. If applicable, include links to documentation or pieces of code.
If your change includes breaking changes please add a codeblock documenting the breaking change:

```
BREAKING CHANGES: This patch changes the behavior of configuration item `foo` to do bar. To keep the existing
behavior please do baz.
```
-->

## Related Issue or Design Document

1. Hydra: to not pass DSN environment variable, when `.Values.hydra.config.dsn` isn't specified. https://github.com/ory/k8s/pull/416
2. Hydra Maester: to not create ClusterRole, when `singleNamespaceMode` is enabled, add relevant permission to Role.
3. Hydra Maester: remove `.Release.Namespace` suffixes for Roles/RoleBindings as they are already per namespace (to unify naming).

<!--
If this pull request

1. is a fix for a known bug, link the issue where the bug was reported in the format of `#1234`;
4. is a fix for a previously unknown bug, explain the bug and how to reproduce it in this pull request;
5. implements a new feature, link the issue containing the design document in the format of `#1234`;
6. improves the documentation, no issue reference is required.

Pull requests introducing new features, which do not have a design document linked are more likely to be rejected and take on average 2-8 weeks longer to
get merged.

You can discuss changes with maintainers either in the Github Discusssions in this repository or
join the [Ory Chat](https://www.ory.sh/chat).
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md) and signed the CLA.
- [ ] I have referenced an issue containing the design document if my change introduces a new feature.
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security vulnerability. 
      If this pull request addresses a security vulnerability, 
      I confirm that I got green light (please contact [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push the changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation within the code base (if appropriate).

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->

DSN change.
When `.Values.hydra.config.dsn` isn't specified - DSN environment variable is passed into the pod with empty value, as it is read from secret, dns key (it is created in any case, with or without value). My suggestion is to not pass DSN environment variable into the pod, when it is empty, and allow user overwrite it with `extraEnv`. If user specifies dsn in `.Values.hydra.config.dsn` it will behave as it does now.

Hydra Maester changes.
- We don't need ClusterRole when `singleNamespaceMode` is enabled, but relevant permissions should be grant to the Role. In our case we are using multiple hydras per environment/namespaces - and if we try to keep unified naming in namespaces, it cause conflicts in ClusterRole names.
- Also I've removed namespace suffixes for Roles/RoleBinding, as they are created per namespace.