### PR TITLE
chore: removed / from helm notes because kratos cli cannot handle the /

### DIFF
--- a/helm/charts/kratos/templates/NOTES.txt
+++ b/helm/charts/kratos/templates/NOTES.txt
@@ -30,7 +30,7 @@ against this endpoint:
   export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "kratos.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
   echo "Visit http://127.0.0.1:{{ .Values.service.public.port }} to use your application"
   kubectl port-forward $POD_NAME {{ .Values.service.public.port }}:{{ .Values.kratos.config.serve.public.port }}
-  export KRATOS_PUBLIC_URL=http://127.0.0.1:{{ .Values.service.public.port }}/
+  export KRATOS_PUBLIC_URL=http://127.0.0.1:{{ .Values.service.public.port }}
 
 
 If you have the ORY Kratos CLI installed locally, you can run commands
@@ -72,7 +72,7 @@ against this endpoint:
   export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "kratos.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
   echo "Visit http://127.0.0.1:{{ .Values.service.admin.port }} to use your application"
   kubectl port-forward $POD_NAME {{ .Values.service.admin.port }}:{{ .Values.kratos.config.serve.admin.port }}
-  export KRATOS_ADMIN_URL=http://127.0.0.1:{{ .Values.service.admin.port }}/
+  export KRATOS_ADMIN_URL=http://127.0.0.1:{{ .Values.service.admin.port }}
 
 If you have the ORY Kratos CLI installed locally, you can run commands
 against this endpoint:


### PR DESCRIPTION
After installing kratos with helm, the notes say:
```
export KRATOS_PUBLIC_URL=http://127.0.0.1:80/
export KRATOS_ADMIN_URL=http://127.0.0.1:80/
```
The kratos cli cannot handle the last `/` (at least version v0.10.1, v0.10.0 and v0.9.0-alpha.3):
```
kratos ls identities 100 1
2022/09/27 08:57:43 [DEBUG] GET http://127.0.0.1:8081//admin/identities?page=100&per_page=1
```
(See `//`)

Just with:
```
export KRATOS_PUBLIC_URL=http://127.0.0.1:80
export KRATOS_ADMIN_URL=http://127.0.0.1:80
```
it works as expected. So I opened this PR to avoid the same issue for others.
Would be happy about a merge =) 