### PR TITLE
docs: update hydra readme

### DIFF
--- a/docs/helm/hydra.md
+++ b/docs/helm/hydra.md
@@ -25,6 +25,8 @@ must be set:
 > `hydra.existingSecret` is empty, a secret is generated automatically. The
 > generated secret is cryptographically secure, and 32 signs long.
 
+> **NOTE:** `hydra.config.dsn` can also be set on [runtime](https://github.com/ory/k8s/blob/master/docs/helm/hydra.md#set-up-dsn-variable-on-runtime).
+
 If you wish to install ORY Hydra with a postgres based database, a
 cryptographically strong secret, a Login and Consent provider located at
 `https://my-idp/` run:
@@ -53,17 +55,6 @@ Alternatively, you can use an existing
 [Kubernetes Secret](https://kubernetes.io/docs/concepts/configuration/secret/)
 instead of letting the Helm Chart create one for you:
 
-Last but not least, if you'd like to customise the way secrets are updated on
-your kubernetes cluster, you can do so via the `hydra.config.secretAnnotations`
-value as follows:
-
-```bash
-$ helm install \
-    --set hydra.config.secretAnnotations."helm\.sh/hook"="pre-install\,pre-upgrade" \
-    --set hydra.config.secretAnnotations."helm\.sh/hook-delete-policy"=before-hook-creation \
-    ory/hydra
-```
-
 ```bash
 
 $ kubectl create secret generic my-secure-secret --from-literal=dsn=postgres://foo:bar@baz:1234/db \
@@ -77,12 +68,23 @@ $ helm install \
     ory/hydra
 ```
 
+Last but not least, if you'd like to customise the way secrets are updated on
+your kubernetes cluster, you can do so via the `hydra.config.secretAnnotations`
+value as follows:
+
+```bash
+$ helm install \
+    --set hydra.config.secretAnnotations."helm\.sh/hook"="pre-install\,pre-upgrade" \
+    --set hydra.config.secretAnnotations."helm\.sh/hook-delete-policy"=before-hook-creation \
+    ory/hydra
+```
+
 ### Local in memory mode
 
 You can also run ORY Hydra with a in memory database. However, this requires
 changing the image tag to the `-sqlite`, which supports this mode of operation.
 
-> **NOTE:\*** This is recommended only for testing, and not intended for
+> **NOTE:** This is recommended only for testing, and not intended for
 > production use, as each replica will have its own db, and the data do not
 > persist an application restart
 
@@ -148,6 +150,8 @@ hydra:
     # e.g.:
     ttl:
       access_token: 1h
+    log:
+      level: trace
     # ...
 ```
 
@@ -159,7 +163,7 @@ $ helm install -f ./path/to/hydra-config.yaml ory/hydra
 
 Additionally, the following extra settings are available:
 
-- `autoMigrate` (bool): If enabled, an `initContainer` running
+- `automigration` (bool): If enabled, an `initContainer` running
   `hydra migrate sql` will be created.
 - `dangerousForceHttp` (bool): If enabled, sets the `--dangerous-force-http`
   flag on `hydra serve all`.
@@ -237,8 +241,8 @@ hydra-example-admin    admin.hydra.localhost    192.168.64.3   80      35s
 or alternatively with
 
 ```bash
-$ minikube ip192.168.64.3
-
+$ minikube ip
+192.168.64.3
 ```
 
 next route the hostnames to the IP Address from above by editing, for example
@@ -399,3 +403,4 @@ where changes are on:
 - change `paths` definition from an array of strings to an array of objects,
   where each object include the `path` and the `pathType` (see
   [path matching documentation](https://kubernetes.io/blog/2020/04/02/improvements-to-the-ingress-api-in-kubernetes-1.18/#better-path-matching-with-path-types))
+

--- a/docs/helm/hydra.md
+++ b/docs/helm/hydra.md
@@ -163,7 +163,7 @@ $ helm install -f ./path/to/hydra-config.yaml ory/hydra
 
 Additionally, the following extra settings are available:
 
-- `automigration` (bool): If enabled, an `initContainer` running
+- `automigration.enabled` (bool): If enabled, a `Job` running
   `hydra migrate sql` will be created.
 - `dangerousForceHttp` (bool): If enabled, sets the `--dangerous-force-http`
   flag on `hydra serve all`.


### PR DESCRIPTION
This PR updates the hydra helm chart install documentation.
It adds a misplaced part about k8s secrets, updates the `autoMigrate` config option to `automigration` and introduces some other minor changes.

## Related Issue or Design Document

none

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md) and signed the CLA.
- [ ] I have referenced an issue containing the design document if my change introduces a new feature.
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security vulnerability. 
      If this pull request addresses a security vulnerability, 
      I confirm that I got approval (please contact [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push the changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added the necessary documentation within the code base (if appropriate).

## Further comments

Following the tutorial with a postgre database deployed in the same cluster:
```
microk8s helm3 install hydra -n test \
    --set 'hydra.config.dsn=postgres://operator:<pwd>@<postgre-ip>:5432/postgres' \
    --set 'hydra.config.urls.self.issuer=http://localhost:4444' \
    --set 'hydra.config.urls.login=http://localhost:3000/login' \
    --set 'hydra.config.urls.consent=http://localhost:3000/consent' \
    --set 'hydra.dangerousForceHttp=true' \
    --set 'hydra.autoMigrate=true' \
    --set 'hydra.config.log.level=trace' \
    ory/hydra
```
It looks that hydra doesn't recognize the db:
```
$ kubectl logs hydra-7c565d9475-79n7k -n test
time=2022-09-26T10:34:09Z level=info msg=No tracer configured - skipping tracing setup audience=application service_name=Ory Hydra service_version=v1.11.8
time=2022-09-26T10:34:09Z level=debug msg=No SQL connection options have been defined, falling back to default connection options. audience=application service_name=Ory Hydra service_version=v1.11.8 sql_max_connection_lifetime=0s sql_max_connections=16 sql_max_idle_connection_time=0s sql_max_idle_connections=8
time=2022-09-26T10:34:09Z level=fatal msg=Could not ensure that signing keys for "hydra.openid.id-token" exists. If you are running against a persistent SQL database this is most likely because your "secrets.system" ("SECRETS_SYSTEM" environment variable) is not set or changed. When running with an SQL database backend you need to make sure that the secret is set and stays the same, unless when doing key rotation. This may also happen when you forget to run "hydra migrate sql".. audience=application error=map[debug: message:Unable to locate the table reason: stack_trace:
github.com/ory/x/sqlcon.handlePostgres
    /go/pkg/mod/github.com/ory/x@v0.0.368/sqlcon/error.go:56
github.com/ory/x/sqlcon.HandleError
    /go/pkg/mod/github.com/ory/x@v0.0.368/sqlcon/error.go:75
github.com/ory/hydra/persistence/sql.(*Persister).GetKeySet
    /project/persistence/sql/persister_jwk.go:139
github.com/ory/hydra/jwk.GetOrGenerateKeys
    /project/jwk/helper.go:47
github.com/ory/hydra/jwk.EnsureAsymmetricKeypairExists
    /project/jwk/helper.go:42
github.com/ory/hydra/driver.(*RegistryBase).newKeyStrategy
    /project/driver/registry_base.go:383
github.com/ory/hydra/driver.(*RegistryBase).OpenIDJWTStrategy
    /project/driver/registry_base.go:414
github.com/ory/hydra/driver.(*RegistryBase).OAuth2Provider
    /project/driver/registry_base.go:320
github.com/ory/hydra/driver.CallRegistry
    /project/driver/registry.go:101
github.com/ory/hydra/driver.New
    /project/driver/factory.go:81
github.com/ory/hydra/cmd/server.RunServeAll
    /project/cmd/server/handler.go:143
github.com/spf13/cobra.(*Command).execute
    /go/pkg/mod/github.com/spf13/cobra@v1.4.0/command.go:860
github.com/spf13/cobra.(*Command).ExecuteC
    /go/pkg/mod/github.com/spf13/cobra@v1.4.0/command.go:974
github.com/spf13/cobra.(*Command).Execute
    /go/pkg/mod/github.com/spf13/cobra@v1.4.0/command.go:902
github.com/ory/hydra/cmd.Execute
    /project/cmd/root.go:87
main.main
    /project/main.go:33
runtime.main
    /usr/local/go/src/runtime/proc.go:255
runtime.goexit
    /usr/local/go/src/runtime/asm_amd64.s:1581 status:Internal Server Error status_code:500] service_name=Ory Hydra service_version=v1.11.8
```
It suggests that the connection can't be established, in fact the `hydra migrate sql` doesn't run because `autoMigrate` was possibly renamed to `automigration`.
The following spins up a hydra-automigrate pod during deployment:
```
microk8s helm3 install hydra -n test \
    ...
    --set 'hydra.automigration.enabled=true' \
    ...
    ory/hydra
```
It should also be updated on the [official docs page](https://www.ory.sh/docs/hydra/guides/kubernetes-helm-chart).