### PR TITLE
feat: add support for running Hydra Janitor as a cron job

### DIFF
--- a/helm/charts/hydra/templates/_helpers.tpl
+++ b/helm/charts/hydra/templates/_helpers.tpl
@@ -191,3 +191,15 @@ Check the migration type value and fail if unexpected
   {{- end }}  
 {{- end }}
 {{- end }}
+
+{{/*
+Common labels for the janitor cron job
+*/}}
+{{- define "hydra.janitor.labels" -}}
+"app.kubernetes.io/name": {{ printf "%s-janitor" (include "hydra.name" .) | quote }}
+"app.kubernetes.io/instance": {{ .Release.Name | quote }}
+"app.kubernetes.io/version": {{ include "hydra.version" . | quote }}
+"app.kubernetes.io/managed-by": {{ .Release.Service | quote }}
+"app.kubernetes.io/component": janitor
+"helm.sh/chart": {{ include "hydra.chart" . | quote }}
+{{- end -}}

--- a/helm/charts/hydra/templates/janitor-cron-job.yaml
+++ b/helm/charts/hydra/templates/janitor-cron-job.yaml
@@ -1,0 +1,103 @@
+{{- if .Values.janitor.enabled -}}
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ include "hydra.fullname" . }}-janitor
+  {{- if .Release.Namespace }}
+  namespace: {{ .Release.Namespace }}
+  {{- end }}
+  labels:
+    {{- include "hydra.janitor.labels" . | nindent 4 }}
+    {{- with .Values.janitor.cronjob.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+  annotations:
+    {{- with .Values.janitor.cronjob.annotations }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  concurrencyPolicy: Forbid
+  schedule: {{ .Values.janitor.cronjob.schedule | quote }}
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          labels:
+            {{- include "hydra.janitor.labels" . | nindent 12 }}
+            {{- with .Values.janitor.cronjob.labels }}
+              {{- toYaml . | nindent 12 }}
+            {{- end }}
+            {{- with .Values.janitor.cronjob.podMetadata.labels }}
+              {{- toYaml . | nindent 12 }}
+            {{- end }}
+          annotations:
+            {{- include "hydra.annotations.checksum" . | nindent 12 -}}
+            {{- with .Values.janitor.cronjob.annotations }}
+              {{- toYaml . | nindent 12 }}
+            {{- end }}
+            {{- with $.Values.janitor.cronjob.podMetadata.annotations }}
+              {{- toYaml . | nindent 12 }}
+            {{- end }}
+        spec:
+          restartPolicy: OnFailure
+          {{- with .Values.imagePullSecrets }}
+          imagePullSecrets:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          volumes:
+            - name: {{ include "hydra.name" . }}-config-volume
+              configMap:
+                name: {{ include "hydra.fullname" . }}
+          containers:
+            - name: janitor
+              image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+              imagePullPolicy: {{ .Values.image.pullPolicy }}
+              {{- if .Values.janitor.cronjob.securityContext.enabled }}
+              securityContext:
+                {{- omit .Values.janitor.cronjob.securityContext "enabled" | toYaml | nindent 16 }}
+              {{- end }}
+              command: ["hydra"]
+              args:
+                - janitor
+                {{- if .Values.janitor.cleanupGrants }}
+                - --grants
+                {{- end }}
+                {{- if .Values.janitor.cleanupRequests }}
+                - --requests
+                {{- end }}
+                {{- if .Values.janitor.cleanupTokens }}
+                - --tokens
+                {{- end }}
+                - --batch-size
+                - {{ .Values.janitor.batchSize | quote }}
+                - --limit
+                - {{ .Values.janitor.limit | quote }}
+                - --config
+                - /etc/config/hydra.yaml
+              env:
+              {{- if not (empty ( include "hydra.dsn" . )) }}
+                - name: DSN
+                  valueFrom:
+                    secretKeyRef:
+                      name: {{ include "hydra.secretname" . }}
+                      key: dsn
+              {{- end }}
+              resources:
+                {{- toYaml .Values.janitor.cronjob.resources | nindent 16 }}
+              volumeMounts:
+                - name: {{ include "hydra.name" . }}-config-volume
+                  mountPath: /etc/config
+                  readOnly: true
+          {{- with .Values.janitor.cronjob.nodeSelector }}
+          nodeSelector:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.janitor.cronjob.tolerations }}
+          tolerations:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.janitor.cronjob.affinity }}
+          affinity:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+{{- end }}

--- a/helm/charts/hydra/values.yaml
+++ b/helm/charts/hydra/values.yaml
@@ -148,12 +148,12 @@ hydra:
     # -- Configure the way to execute database migration. Possible values: job, initContainer
     # When set to job, the migration will be executed as a job on release or upgrade.
     # When set to initContainer, the migration will be executed when kratos pod is created
-    # Defaults to job  
+    # Defaults to job
     type: job
     # -- Ability to override the entrypoint of the automigration container
     # (e.g. to source dynamic secrets or export environment dynamic variables)
     customCommand: []
-    # -- Ability to override arguments of the entrypoint. Can be used in-depended of customCommand  
+    # -- Ability to override arguments of the entrypoint. Can be used in-depended of customCommand
     # eg:
     # - sleep 5;
     #   - kratos
@@ -393,6 +393,71 @@ watcher:
     labels: {}
     # -- Extra pod level annotations
     annotations: {}
+
+## -- Janitor cron job configuration
+janitor:
+  # -- Enable cleanup of stale database rows by periodically running the janitor command
+  enabled: false
+
+  ## -- Configure if the trust relationships must be cleaned up
+  cleanupGrants: false
+
+  ## -- Configure if the consent and authentication requests must be cleaned up
+  cleanupRequests: false
+
+  ## -- Configure if the access and refresh tokens must be cleaned up
+  cleanupTokens: false
+
+  ## -- Configure how many records are deleted with each iteration
+  batchSize: 100
+
+  ## -- Configure how many records are retrieved from database for deletion
+  limit: 10000
+
+  cronjob:
+    # -- Configure how often the cron job is ran
+    schedule: "0 */1 * * *"
+
+    # -- Set custom cron job level labels
+    labels: {}
+
+    # -- Set custom cron job level annotations
+    annotations: {}
+
+    # -- Specify pod metadata, this metadata is added directly to the pod, and not higher objects
+    podMetadata:
+      # -- Extra pod level labels
+      labels: {}
+
+      # -- Extra pod level annotations
+      annotations: {}
+
+    # -- Configure node labels for pod assignment
+    nodeSelector: {}
+
+    # -- Configure node tolerations
+    tolerations: []
+
+    # -- Configure node affinity
+    affinity: {}
+
+    # -- We usually recommend not to specify default resources and to leave this as a conscious choice for the user.
+    #  This also increases chances charts run on environments with little
+    #  resources, such as Minikube. If you do want to specify resources, uncomment the following
+    #  lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+    #  limits:
+    #    cpu: 100m
+    #    memory: 128Mi
+    #  requests:
+    #    cpu: 100m
+    #  memory: 128Mi
+    resources:
+      limits: {}
+      requests: {}
+
+    # -- Configure the containers' SecurityContext
+    securityContext:
+      enabled: false
 
 # -- PodDistributionBudget configuration
 pdb:


### PR DESCRIPTION
## Related Issue or Design Document

Fixes #513. I added a `CronJob` resource, disabled by default, that can be configured to run `hydra janitor` at a specific interval. I decided to not support all available CLI flags because I don't see the need to customize them. However, I'm open to change my mind if you think that we should make all of them configurable. Below a little table that lists each option of the command and whether it is configurable or not via Helm values:

| CLI flag | Configurable |
| - | - |
| `--access-lifespan` | :x: |
| `--batch-size` | ✅ |
| `--consent-request-lifespan` | :x: |
| `--grants` | ✅ |
| `--keep-if-younger` | :x: |
| `--limit` | ✅ |
| `--refresh-lifespan duration` | :x: |
| `--requests` | ✅|
| `--tokens` | ✅|

I tested all available Helm values related to `janitor` on a development Kubernetes cluster and it seems to work fine.

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md) and signed the CLA.
- [x] I have referenced an issue containing the design document if my change introduces a new feature.
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security vulnerability. 
      If this pull request addresses a security vulnerability, 
      I confirm that I got approval (please contact [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push the changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added the necessary documentation within the code base (if appropriate).