### PR TITLE
fix: expose --endpoint argument in chart for Hydra 2.x support

### DIFF
--- a/helm/charts/hydra-maester/templates/deployment.yaml
+++ b/helm/charts/hydra-maester/templates/deployment.yaml
@@ -50,6 +50,9 @@ spec:
             - --metrics-addr=127.0.0.1:8080
             - --hydra-url=http://{{ .Values.adminService.name | default ( include "hydra-maester.adminService" . ) }}
             - --hydra-port={{ .Values.adminService.port | default 4445 }}
+            {{- with .Values.adminService.endpoint }}
+            - --endpoint={{ . }}
+            {{- end }}
             {{- if .Values.forwardedProto }}
             - --forwarded-proto={{ .Values.forwardedProto }}
             {{- end }}

--- a/helm/charts/hydra-maester/values.yaml
+++ b/helm/charts/hydra-maester/values.yaml
@@ -28,6 +28,9 @@ adminService:
   name:
   # -- Service port
   port:
+  # -- Set the clients endpoint, should be `/clients` for Hydra 1.x and
+  # `/admin/clients` for Hydra 2.x
+  endpoint: /admin/clients
 
 forwardedProto:
 


### PR DESCRIPTION


<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.

This text will be included in the changelog. If applicable, include links to documentation or pieces of code.
If your change includes breaking changes please add a code block documenting the breaking change:

```
BREAKING CHANGES: This patch changes the behavior of configuration item `foo` to do bar. To keep the existing
behavior please do baz.
```
-->

Expose the `--endpoint` argument of `hydra-maester` so a fresh install of `hydra-maester` works correctly with Hydra 2.x.


**BREAKING CHANGES:** This patch changes `adminService.endpoint` to `/admin/clients` to be
compatible with `Hydra 2.x`. To keep the existing behavior (for `Hydra 1.x`) please set
`adminService.endpoint` to `/clients`.


## Related Issue or Design Document

New Issue: The `hydra-maester` chart does not expose the `--endpoint` argument which needs to be set to `/admin/clients` for Hydra 2.x.

Hydra does perform a `307` redirect but this includes the `localhost` portion which cause the following error. This error was a bit confusing to me at first becuase I thought I had just misconfigured maester but after pulling a local copy of maester and running `dlv` I could see that it's just [following `307` in `ListOAuth2Client`](https://github.com/ory/hydra-maester/blob/77d196e886075b636384a213cd2d38c5c7edf4f7/hydra/client.go#L91):

```
2022-11-06T11:41:20.925Z        ERROR   controller-runtime.manager.controller.oauth2client      Reconciler error        {"reconciler group": "hydra.ory.sh", "reconciler kind": "OAuth2Client", "name": "hydra-test-client", "namespace": "hydra", "error": "Get \"https://localhost:4445/admin/clients\": dial tcp [::1]:4445: connect: connection refused"}
github.com/go-logr/zapr.(*zapLogger).Error
        /go/pkg/mod/github.com/go-logr/zapr@v0.2.0/zapr.go:132
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler
        /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.8.3/pkg/internal/controller/controller.go:302
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem
        /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.8.3/pkg/internal/controller/controller.go:253
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func1.2
        /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.8.3/pkg/internal/controller/controller.go:216
k8s.io/apimachinery/pkg/util/wait.JitterUntilWithContext.func1
        /go/pkg/mod/k8s.io/apimachinery@v0.20.2/pkg/util/wait/wait.go:185
k8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1
        /go/pkg/mod/k8s.io/apimachinery@v0.20.2/pkg/util/wait/wait.go:155
k8s.io/apimachinery/pkg/util/wait.BackoffUntil
        /go/pkg/mod/k8s.io/apimachinery@v0.20.2/pkg/util/wait/wait.go:156
k8s.io/apimachinery/pkg/util/wait.JitterUntil
        /go/pkg/mod/k8s.io/apimachinery@v0.20.2/pkg/util/wait/wait.go:133
k8s.io/apimachinery/pkg/util/wait.JitterUntilWithContext
        /go/pkg/mod/k8s.io/apimachinery@v0.20.2/pkg/util/wait/wait.go:185
k8s.io/apimachinery/pkg/util/wait.UntilWithContext
        /go/pkg/mod/k8s.io/apimachinery@v0.20.2/pkg/util/wait/wait.go:99
```

I verified this behavior by starting 2 hydra servers in kubernetes, a 1.11.x and 2.x and the redirect can be seen/verified.

### Hydra 1.x:

```console
% kubectl port-forward -n hydra svc/hydra1x-test-admin 4446:4445

% curl -H "X-Forwarded-Proto: https" http://127.0.0.1:4446/clients
[]

% curl -H "X-Forwarded-Proto: https" http://127.0.0.1:4446/admin/clients
<!DOCTYPE html>
<html lang="en">
<head>
    <meta charset="UTF-8">
    <title>404 - Route not found</title>
```

### Hydra 2.x:

```console
% kubectl port-forward -n hydra svc/hydra2x-test-admin 4447:4445

% curl -H "X-Forwarded-Proto: https" http://127.0.0.1:4447/admin/clients
[]

% curl -H "X-Forwarded-Proto: https" http://127.0.0.1:4447/clients
<a href="https://localhost:4445/admin/clients">Temporary Redirect</a>.

% curl -v -H "X-Forwarded-Proto: https" http://127.0.0.1:4447/clients
*   Trying 127.0.0.1:4447...
* Connected to 127.0.0.1 (127.0.0.1) port 4447 (#0)
> GET /clients HTTP/1.1
> Host: 127.0.0.1:4447
> User-Agent: curl/7.79.1
> Accept: */*
> X-Forwarded-Proto: https
>
* Mark bundle as not supporting multiuse
< HTTP/1.1 307 Temporary Redirect
< Cache-Control: private, no-cache, no-store, must-revalidate
< Content-Type: text/html; charset=utf-8
< Location: https://localhost:4445/admin/clients
< Date: Sun, 06 Nov 2022 16:42:22 GMT
< Content-Length: 72
<
<a href="https://localhost:4445/admin/clients">Temporary Redirect</a>.

* Connection #0 to host 127.0.0.1 left intact
```

### Alternatives

For now, if each `OAuth2Client` specifies the following, the default client won't be used:

```yaml
  hydraAdmin:
    url: http://hydra2x-test-admin.hydra
    port: 4445
    endpoint: /admin/clients
    forwardedProto: https
```

The same can work to send requests to a 1.x server (if the default is configured for 2.x):

```yaml
  hydraAdmin:
    url: http://hydra1x-test-admin.hydra
    port: 4445
    endpoint: /clients
    forwardedProto: https
```


## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md) and signed the CLA.
- [ ] I have referenced an issue containing the design document if my change introduces a new feature.
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security vulnerability. 
      If this pull request addresses a security vulnerability, 
      I confirm that I got approval (please contact [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push the changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added the necessary documentation within the code base (if appropriate).

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->