### PR TITLE
fix: notes for example-idp in ingress mode

### DIFF
--- a/helm/charts/example-idp/templates/NOTES.txt
+++ b/helm/charts/example-idp/templates/NOTES.txt
@@ -2,7 +2,7 @@
 {{- if .Values.ingress.enabled }}
 {{- range $host := .Values.ingress.hosts }}
   {{- range .paths }}
-  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ . }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
   {{- end }}
 {{- end }}
 {{- else if contains "NodePort" .Values.service.type }}


### PR DESCRIPTION
## Description

There is a bug in the NOTES.txt that corrupts shown address. 
To reproduce this bug you need to install/upgrade release with values
```
ingress:
  enabled: true
```

Previously notes used the whole path structure instead of the path itself.  It was leading to an incorrect path shown after helm install/upgrade. 
The path before changes: 
```
1. Get the application URL by running these commands:
  https://example-idp.int.chainstack.commap[path:/ pathType:ImplementationSpecific]
```
The path after changes:
```
1. Get the application URL by running these commands:
  https://example-idp.int.chainstack.com/
```

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md) and signed the CLA.
- [ ] I have referenced an issue containing the design document if my change introduces a new feature.
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security vulnerability. 
      If this pull request addresses a security vulnerability, 
      I confirm that I got approval (please contact [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push the changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added the necessary documentation within the code base (if appropriate).