### PR TITLE
feat: add config to disable courier

### DIFF
--- a/helm/charts/kratos/README.md
+++ b/helm/charts/kratos/README.md
@@ -132,6 +132,7 @@ A ORY Kratos Helm chart for Kubernetes
 | statefulSet.topologySpreadConstraints | list | `[]` | Configure pod topologySpreadConstraints. |
 | strategy | object | `{"rollingUpdate":{"maxSurge":"30%","maxUnavailable":0},"type":"RollingUpdate"}` | Deployment update strategy |
 | tolerations | list | `[]` | If you do want to specify node labels, uncomment the following lines, adjust them as necessary, and remove the curly braces after 'annotations:'.   foo: bar Configure node tolerations. |
+| courier.enabled | boolean | `true` |  |
 | watcher | object | `{"enabled":false,"image":"oryd/k8s-toolbox:0.0.4","mountFile":"","podMetadata":{"annotations":{},"labels":{}},"watchLabelKey":"ory.sh/watcher"}` | Configuration of the watcher sidecar |
 | watcher.mountFile | string | `""` | Path to mounted file, which wil be monitored for changes. eg: /etc/secrets/my-secret/foo |
 | watcher.podMetadata | object | `{"annotations":{},"labels":{}}` | Specify pod metadata, this metadata is added directly to the pod, and not higher objects |

--- a/helm/charts/kratos/templates/statefulset-mail.yaml
+++ b/helm/charts/kratos/templates/statefulset-mail.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.courier.enabled -}}
 {{- $resources := ternary .Values.deployment.resources .Values.resources (not (empty .Values.deployment.resources )) -}}
 {{- $annotations := ternary .Values.statefulSet.annotations .Values.deployment.annotations (not (empty .Values.statefulSet.annotations )) -}}
 {{- $labels := ternary .Values.statefulSet.labels .Values.deployment.labels (not (empty .Values.statefulSet.labels )) -}}
@@ -149,3 +150,4 @@ spec:
       topologySpreadConstraints:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+{{- end }}

--- a/helm/charts/kratos/templates/statefulset-svc.yaml
+++ b/helm/charts/kratos/templates/statefulset-svc.yaml
@@ -1,6 +1,6 @@
 # Headless Service for StatefulSet. See https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#limitations 
 # and https://kubernetes.io/docs/concepts/services-networking/service/#headless-services for details.
-{{- if .Values.courier.enabled -}}
+{{- if .Values.courier.enabled }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/helm/charts/kratos/templates/statefulset-svc.yaml
+++ b/helm/charts/kratos/templates/statefulset-svc.yaml
@@ -1,5 +1,6 @@
 # Headless Service for StatefulSet. See https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#limitations 
 # and https://kubernetes.io/docs/concepts/services-networking/service/#headless-services for details.
+{{- if .Values.courier.enabled -}}
 apiVersion: v1
 kind: Service
 metadata:
@@ -27,3 +28,4 @@ spec:
   selector:
     app.kubernetes.io/name: {{ include "kratos.fullname" . }}-courier
     app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/helm/charts/kratos/values.yaml
+++ b/helm/charts/kratos/values.yaml
@@ -501,6 +501,10 @@ nodeSelector: {}
 # Configure node tolerations.
 tolerations: []
 
+# -- Configuration of the courier
+courier:
+  enabled: true
+
 # -- Configuration of the watcher sidecar
 watcher:
   enabled: false


### PR DESCRIPTION
To enable self-service for multiple schemas, you must run multiple Kratos instances with different default schema. There is no such configuration available currently in the Kratos Helm Chart. It could be accomplished by running multiple releases of the chart - but it will result in spawning multiple couriers - leading to multiplying emails send.

This PR is simply adding option to disable courier, allowing to enable it only for one release of Kratos.

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md) and signed the CLA.
- [ ] I have referenced an issue containing the design document if my change introduces a new feature.
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security vulnerability. 
      If this pull request addresses a security vulnerability, 
      I confirm that I got approval (please contact [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push the changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added the necessary documentation within the code base (if appropriate).