### PR TITLE
fix: support recovery_code and verification_code email templates

### DIFF
--- a/hacks/values/kratos.yaml
+++ b/hacks/values/kratos.yaml
@@ -100,7 +100,7 @@ kratos:
           However, this email address is not on our database of registered users and therefore the attempt has failed. If this was you, check if you signed up using a different address. If this was not you, please ignore this email.
         plainBody: |-
           Hi, you (or someone else) entered this email address when trying to recover access to an account.
-    recovery-code:
+    recovery_code:
       valid:
         subject: Recover access to your account
         body: |-
@@ -127,7 +127,7 @@ kratos:
         subject:
         body:
         plainBody:
-    verification-code:
+    verification_code:
       valid:
         subject: Please verify your email address
         body: |-

--- a/hacks/values/kratos.yaml
+++ b/hacks/values/kratos.yaml
@@ -100,6 +100,21 @@ kratos:
           However, this email address is not on our database of registered users and therefore the attempt has failed. If this was you, check if you signed up using a different address. If this was not you, please ignore this email.
         plainBody: |-
           Hi, you (or someone else) entered this email address when trying to recover access to an account.
+    recovery-code:
+      valid:
+        subject: Recover access to your account
+        body: |-
+          Hi, please recover access to your account using following code:
+          <h1>{{ .RecoveryCode }}</h1>
+        plainBody: |-
+          Hi, please recover access to your account using following code: {{ .RecoveryCode }}
+      invalid:
+        subject: Account access attempted
+        body: |-
+          Hi, you (or someone else) entered this email address when trying to recover access to an account.
+          However, this email address is not on our database of registered users and therefore the attempt has failed. If this was you, check if you signed up using a different address. If this was not you, please ignore this email.
+        plainBody: |-
+          Hi, you (or someone else) entered this email address when trying to recover access to an account.
     verification:
       valid:
         subject: Please verify your email address
@@ -108,6 +123,19 @@ kratos:
           <a href="{{ .VerificationURL }}">{{ .VerificationURL }}</a>
         plainBody: |-
           Hi, please verify your account by clicking the following link: {{ .VerificationURL }}
+      invalid:
+        subject:
+        body:
+        plainBody:
+    verification-code:
+      valid:
+        subject: Please verify your email address
+        body: |-
+          Hi, please verify your account by clicking the following link:
+          <a href="{{ .VerificationURL }}">{{ .VerificationURL }}</a>
+          or using the following code: {{ .VerificationCode }}
+        plainBody: |-
+          Hi, please verify your account by using the following code: {{ .VerificationCode }}
       invalid:
         subject:
         body:

--- a/helm/charts/kratos/templates/configmap-templates.yaml
+++ b/helm/charts/kratos/templates/configmap-templates.yaml
@@ -5,7 +5,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ include "kratos.fullname" $root }}-template-{{ $method }}-{{ $result }}
+  name: {{ include "kratos.fullname" $root }}-template-{{ $method | kebabcase }}-{{ $result }}
   namespace: {{ $root.Release.Namespace }}
   labels:
     {{- include "kratos.labels" $root | nindent 4 }}

--- a/helm/charts/kratos/templates/deployment-kratos.yaml
+++ b/helm/charts/kratos/templates/deployment-kratos.yaml
@@ -98,9 +98,9 @@ spec:
         {{- $root := . -}}
         {{- range $method, $methodEntry := .Values.kratos.emailTemplates }}
         {{- range $result, $resultEntry := $methodEntry }}
-        - name: {{ include "kratos.name" $root }}-template-{{ $method }}-{{ $result }}-volume
+        - name: {{ include "kratos.name" $root }}-template-{{ $method | kebabcase }}-{{ $result }}-volume
           configMap:
-            name: {{ include "kratos.fullname" $root }}-template-{{ $method }}-{{ $result }}
+            name: {{ include "kratos.fullname" $root }}-template-{{ $method | kebabcase }}-{{ $result }}
         {{- end }}
         {{- end }}
       automountServiceAccountToken: {{ .Values.deployment.automountServiceAccountToken }}

--- a/helm/charts/kratos/templates/deployment-kratos.yaml
+++ b/helm/charts/kratos/templates/deployment-kratos.yaml
@@ -133,7 +133,7 @@ spec:
             {{- range $method, $methodEntry := .Values.kratos.emailTemplates }}
             {{- range $result, $resultEntry := $methodEntry }}
             - name: {{ include "kratos.name" $root }}-template-{{ $method }}-{{ $result }}-volume
-              mountPath: /conf/courier-templates/{{ $method }}/{{ $result }}
+              mountPath: /conf/courier-templates/{{ $method | snakecase }}/{{ $result }}
               readOnly: true
             {{- end }}
             {{- end }}

--- a/helm/charts/kratos/templates/deployment-kratos.yaml
+++ b/helm/charts/kratos/templates/deployment-kratos.yaml
@@ -132,7 +132,7 @@ spec:
             {{- $root := . -}}
             {{- range $method, $methodEntry := .Values.kratos.emailTemplates }}
             {{- range $result, $resultEntry := $methodEntry }}
-            - name: {{ include "kratos.name" $root }}-template-{{ $method }}-{{ $result }}-volume
+            - name: {{ include "kratos.name" $root }}-template-{{ $method | kebabcase }}-{{ $result }}-volume
               mountPath: /conf/courier-templates/{{ $method | snakecase }}/{{ $result }}
               readOnly: true
             {{- end }}

--- a/helm/charts/kratos/templates/statefulset-mail.yaml
+++ b/helm/charts/kratos/templates/statefulset-mail.yaml
@@ -139,9 +139,9 @@ spec:
         {{- $root := . -}}
         {{- range $method, $methodEntry := .Values.kratos.emailTemplates }}
         {{- range $result, $resultEntry := $methodEntry }}
-        - name: {{ include "kratos.name" $root }}-template-{{ $method }}-{{ $result }}-volume
+        - name: {{ include "kratos.name" $root }}-template-{{ $method | kebabcase }}-{{ $result }}-volume
           configMap:
-            name: {{ include "kratos.fullname" $root }}-template-{{ $method }}-{{ $result }}
+            name: {{ include "kratos.fullname" $root }}-template-{{ $method | kebabcase }}-{{ $result }}
         {{- end }}
         {{- end }}
       {{- with $nodeSelector }}

--- a/helm/charts/kratos/templates/statefulset-mail.yaml
+++ b/helm/charts/kratos/templates/statefulset-mail.yaml
@@ -73,8 +73,8 @@ spec:
             {{- $root := . -}}
             {{- range $method, $methodEntry := .Values.kratos.emailTemplates }}
             {{- range $result, $resultEntry := $methodEntry }}
-            - name: {{ include "kratos.name" $root }}-template-{{ $method }}-{{ $result }}-volume
-              mountPath: /conf/courier-templates/{{ $method }}/{{ $result }}
+            - name: {{ include "kratos.name" $root }}-template-{{ $method | kebabcase }}-{{ $result }}-volume
+              mountPath: /conf/courier-templates/{{ $method | snakecase }}/{{ $result }}
               readOnly: true
             {{- end }}
             {{- end }}

--- a/helm/charts/kratos/values.yaml
+++ b/helm/charts/kratos/values.yaml
@@ -138,6 +138,8 @@ kratos:
   #    {{ .Values.phone_schema }}
 
   # -- You can customize the emails kratos is sending (also uncomment config.courier.template_override_path below)
+  # Note for recovery code and verification code, please use kebab-case on name, e.g. recovery-code: ...
+  # This is because underscore isn't allowed in configmap name.
   emailTemplates: {}
   # emailTemplates:
   #   recovery:

--- a/helm/charts/kratos/values.yaml
+++ b/helm/charts/kratos/values.yaml
@@ -138,8 +138,6 @@ kratos:
   #    {{ .Values.phone_schema }}
 
   # -- You can customize the emails kratos is sending (also uncomment config.courier.template_override_path below)
-  # Note for recovery code and verification code, please use kebab-case on name, e.g. recovery-code: ...
-  # This is because underscore isn't allowed in configmap name.
   emailTemplates: {}
   # emailTemplates:
   #   recovery:


### PR DESCRIPTION
Currently in the Kratos chart, we cannot use the `emailTemplates` config to set recovery/verification code templates because `_` isn't allowed in configmap name. 

This PR fixes this by allowing user to use `verification-code` or `recovery-code` key to set these templates. 

## Related Issue or Design Document

N/A

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md) and signed the CLA.
- [ ] I have referenced an issue containing the design document if my change introduces a new feature.
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security vulnerability. 
      If this pull request addresses a security vulnerability, 
      I confirm that I got approval (please contact [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push the changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added the necessary documentation within the code base (if appropriate).

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
