### PR TITLE
fix: consistent hpa api version

### DIFF
--- a/helm/charts/hydra/templates/hpa.yaml
+++ b/helm/charts/hydra/templates/hpa.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.deployment.autoscaling.enabled }}
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   namespace: {{ .Release.Namespace }}

--- a/helm/charts/keto/templates/hpa.yaml
+++ b/helm/charts/keto/templates/hpa.yaml
@@ -1,7 +1,7 @@
 {{- $autoscaling := ternary .Values.deployment.autoscaling .Values.autoscaling (not (empty .Values.deployment.autoscaling )) -}}
 
 {{- if $autoscaling.enabled }}
-apiVersion: autoscaling/v2beta1
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "keto.fullname" . }}

--- a/helm/charts/kratos/templates/hpa-v2.yaml
+++ b/helm/charts/kratos/templates/hpa-v2.yaml
@@ -1,5 +1,5 @@
-{{- if and (.Values.autoscaling.enabled) (.Capabilities.APIVersions.Has "autoscaling/v2beta2") }}
-apiVersion: autoscaling/v2beta2
+{{- if and (.Values.autoscaling.enabled) (.Capabilities.APIVersions.Has "autoscaling/v2") }}
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "kratos.fullname" . }}

--- a/helm/charts/oathkeeper/templates/hpa-controller.yaml
+++ b/helm/charts/oathkeeper/templates/hpa-controller.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.deployment.autoscaling.enabled }}
-apiVersion: autoscaling/v2beta1
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "oathkeeper.fullname" . }}


### PR DESCRIPTION
## Related Issue or Design Document

Since Hydra and Kratos are using v2beta2 HPA API version, and Keto and Oathkeeper use v2beta1, we have some inconsistency across the charts.
This patch fix that and bring all modules to the latest version defined.

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md) and signed the CLA.
- [x] I have referenced an issue containing the design document if my change introduces a new feature.
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security vulnerability. 
      If this pull request addresses a security vulnerability, 
      I confirm that I got approval (please contact [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push the changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added the necessary documentation within the code base (if appropriate).
