### PR TITLE
fix: make namespace handling consistent across the charts

### DIFF
--- a/helm/charts/example-idp/templates/ingress.yaml
+++ b/helm/charts/example-idp/templates/ingress.yaml
@@ -8,7 +8,9 @@ apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: {{ $fullName }}
+  {{- if .Release.Namespace }}
   namespace: {{ .Release.Namespace }}
+  {{- end }}
   labels:
     {{- include "example-idp.labels" . | nindent 4 }}
   {{- with .Values.ingress.annotations }}

--- a/helm/charts/example-idp/templates/tests/test-connection.yaml
+++ b/helm/charts/example-idp/templates/tests/test-connection.yaml
@@ -2,6 +2,9 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: "{{ include "example-idp.fullname" . }}-test-connection"
+  {{- if .Release.Namespace }}
+  namespace: {{ .Release.Namespace }}
+  {{- end }}
   labels:
 {{ include "example-idp.labels" . | indent 4 }}
   annotations:

--- a/helm/charts/hydra/templates/configmap-automigrate.yaml
+++ b/helm/charts/hydra/templates/configmap-automigrate.yaml
@@ -3,7 +3,9 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "hydra.fullname" . }}-migrate
+  {{- if .Release.Namespace }}
   namespace: {{ .Release.Namespace }}
+  {{- end }}
   labels:
     {{- include "hydra.labels" . | nindent 4 }}
   annotations:

--- a/helm/charts/hydra/templates/configmap.yaml
+++ b/helm/charts/hydra/templates/configmap.yaml
@@ -2,7 +2,9 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "hydra.fullname" . }}
+  {{- if .Release.Namespace }}
   namespace: {{ .Release.Namespace }}
+  {{- end }}
   labels:
     {{- include "hydra.labels" . | nindent 4 }}
 data:

--- a/helm/charts/hydra/templates/hpa.yaml
+++ b/helm/charts/hydra/templates/hpa.yaml
@@ -2,7 +2,9 @@
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
+  {{- if .Release.Namespace }}
   namespace: {{ .Release.Namespace }}
+  {{- end }}
   name: {{ include "hydra.fullname" . }}
   labels:
     {{- include "hydra.labels" . | nindent 4 }}

--- a/helm/charts/hydra/templates/ingress-admin.yaml
+++ b/helm/charts/hydra/templates/ingress-admin.yaml
@@ -8,7 +8,9 @@ apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: {{ $fullName }}-admin
+  {{- if .Release.Namespace }}
   namespace: {{ .Release.Namespace }}
+  {{- end }}
   labels:
     {{- include "hydra.labels" . | nindent 4 }}
   {{- with .Values.ingress.admin.annotations }}

--- a/helm/charts/hydra/templates/ingress-public.yaml
+++ b/helm/charts/hydra/templates/ingress-public.yaml
@@ -8,7 +8,9 @@ apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: {{ $fullName }}-public
+  {{- if .Release.Namespace }}
   namespace: {{ .Release.Namespace }}
+  {{- end }}
   labels:
     {{- include "hydra.labels" . | nindent 4 }}
   {{- with .Values.ingress.public.annotations }}

--- a/helm/charts/hydra/templates/job-rbac.yaml
+++ b/helm/charts/hydra/templates/job-rbac.yaml
@@ -4,6 +4,9 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "hydra.job.serviceAccountName" . }}
+  {{- if .Release.Namespace }}
+  namespace: {{ .Release.Namespace }}
+  {{- end }}
   labels:
     {{- include "hydra.labels" . | nindent 4 }}
   {{- with .Values.job.serviceAccount.annotations }}

--- a/helm/charts/hydra/templates/rbac-watcher.yaml
+++ b/helm/charts/hydra/templates/rbac-watcher.yaml
@@ -4,6 +4,9 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "hydra.serviceAccountName" . }}-watcher
+  {{- if .Release.Namespace }}
+  namespace: {{ .Release.Namespace }}
+  {{- end }}
   labels:
     app.kubernetes.io/name: {{ include "hydra.name" . }}-watcher
     app.kubernetes.io/instance: {{ .Release.Name }}
@@ -35,7 +38,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ include "hydra.fullname" . }}-watcher
+  {{- if .Release.Namespace }}
   namespace: {{ .Release.Namespace }}
+  {{- end }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/helm/charts/hydra/templates/rbac.yaml
+++ b/helm/charts/hydra/templates/rbac.yaml
@@ -4,6 +4,9 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "hydra.serviceAccountName" . }}
+  {{- if .Release.Namespace }}
+  namespace: {{ .Release.Namespace }}
+  {{- end }}
   labels:
     {{- include "hydra.labels" . | nindent 4 }}
   {{- with .Values.deployment.serviceAccount.annotations }}

--- a/helm/charts/hydra/templates/secrets.yaml
+++ b/helm/charts/hydra/templates/secrets.yaml
@@ -3,7 +3,9 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "hydra.secretname" . }}
+  {{- if .Release.Namespace }}
   namespace: {{ .Release.Namespace }}
+  {{- end }}
   labels:
     {{- include "hydra.labels" . | nindent 4 }}
   annotations:

--- a/helm/charts/hydra/templates/service-admin.yaml
+++ b/helm/charts/hydra/templates/service-admin.yaml
@@ -4,7 +4,9 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "hydra.fullname" . }}-admin
+  {{- if .Release.Namespace }}
   namespace: {{ .Release.Namespace }}
+  {{- end }}
   labels:
     {{- include "hydra.labels" . | nindent 4 }}
     {{- with .Values.service.admin.labels }}
@@ -31,7 +33,9 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ include "hydra.fullname" . }}-admin
+  {{- if .Release.Namespace }}
   namespace: {{ .Release.Namespace }}
+  {{- end }}
   labels:
     app.kubernetes.io/component: admin
     {{- include "hydra.labels" . | nindent 4 }}

--- a/helm/charts/hydra/templates/service-public.yaml
+++ b/helm/charts/hydra/templates/service-public.yaml
@@ -3,7 +3,9 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "hydra.fullname" . }}-public
+  {{- if .Release.Namespace }}
   namespace: {{ .Release.Namespace }}
+  {{- end }}
   labels:
     {{- include "hydra.labels" . | nindent 4 }}
     {{- with .Values.service.public.labels }}

--- a/helm/charts/keto/templates/configmap-migrate.yaml
+++ b/helm/charts/keto/templates/configmap-migrate.yaml
@@ -3,7 +3,9 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "keto.fullname" . }}-migrate
+  {{- if .Release.Namespace }}
   namespace: {{ .Release.Namespace }}
+  {{- end }}
   labels:
 {{ include "keto.labels" . | indent 4 }}
   annotations:

--- a/helm/charts/keto/templates/configmap.yaml
+++ b/helm/charts/keto/templates/configmap.yaml
@@ -2,7 +2,9 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "keto.fullname" . }}-config
+  {{- if .Release.Namespace }}
   namespace: {{ .Release.Namespace }}
+  {{- end }}
   labels:
 {{ include "keto.labels" . | indent 4 }}
 data:

--- a/helm/charts/keto/templates/ingress-read.yaml
+++ b/helm/charts/keto/templates/ingress-read.yaml
@@ -8,7 +8,9 @@ apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: {{ $fullName }}-read
+  {{- if .Release.Namespace }}
   namespace: {{ .Release.Namespace }}
+  {{- end }}
   labels:
     {{- include "keto.labels" . | nindent 4 }}
   {{- with .Values.ingress.read.annotations }}

--- a/helm/charts/keto/templates/ingress-write.yaml
+++ b/helm/charts/keto/templates/ingress-write.yaml
@@ -8,7 +8,9 @@ apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: {{ $fullName }}-write
+  {{- if .Release.Namespace }}
   namespace: {{ .Release.Namespace }}
+  {{- end }}
   labels:
     {{- include "keto.labels" . | nindent 4 }}
   {{- with .Values.ingress.write.annotations }}

--- a/helm/charts/keto/templates/job-rbac.yaml
+++ b/helm/charts/keto/templates/job-rbac.yaml
@@ -4,6 +4,9 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "keto.job.serviceAccountName" . }}
+  {{- if .Release.Namespace }}
+  namespace: {{ .Release.Namespace }}
+  {{- end }}
   labels:
     {{- include "keto.labels" . | nindent 4 }}
   {{- with .Values.job.serviceAccount.annotations }}

--- a/helm/charts/keto/templates/rbac-watcher.yaml
+++ b/helm/charts/keto/templates/rbac-watcher.yaml
@@ -4,6 +4,9 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "keto.serviceAccountName" . }}-watcher
+  {{- if .Release.Namespace }}
+  namespace: {{ .Release.Namespace }}
+  {{- end }}
   labels:
     app.kubernetes.io/name: {{ include "keto.name" . }}-watcher
     app.kubernetes.io/instance: {{ .Release.Name }}
@@ -12,7 +15,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ include "keto.fullname" . }}-watcher
+  {{- if .Release.Namespace }}
   namespace: {{ .Release.Namespace }}
+  {{- end }}
 rules:
   - apiGroups: ["apps"]
     resources: ["deployments"]
@@ -35,7 +40,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ include "keto.fullname" . }}-watcher
+  {{- if .Release.Namespace }}
   namespace: {{ .Release.Namespace }}
+  {{- end }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/helm/charts/keto/templates/rbac.yaml
+++ b/helm/charts/keto/templates/rbac.yaml
@@ -4,6 +4,9 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "keto.serviceAccountName" . }}
+  {{- if .Release.Namespace }}
+  namespace: {{ .Release.Namespace }}
+  {{- end }}
   labels:
     {{- include "keto.labels" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}

--- a/helm/charts/keto/templates/secrets.yaml
+++ b/helm/charts/keto/templates/secrets.yaml
@@ -3,7 +3,9 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "keto.secretname" . }}
+  {{- if .Release.Namespace }}
   namespace: {{ .Release.Namespace }}
+  {{- end }}
   labels:
 {{ include "keto.labels" . | indent 4 }}
   annotations:

--- a/helm/charts/keto/templates/servicemonitor-metrics.yaml
+++ b/helm/charts/keto/templates/servicemonitor-metrics.yaml
@@ -4,7 +4,9 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ include "keto.fullname" . }}-metrics
+  {{- if .Release.Namespace }}
   namespace: {{ .Release.Namespace }}
+  {{- end }}
   labels:
     app.kubernetes.io/component: metrics
 {{ include "keto.labels" . | indent 4 }}

--- a/helm/charts/keto/templates/tests/test-connection.yaml
+++ b/helm/charts/keto/templates/tests/test-connection.yaml
@@ -2,6 +2,9 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: "{{ include "keto.fullname" . }}-test-connection"
+  {{- if .Release.Namespace }}
+  namespace: {{ .Release.Namespace }}
+  {{- end }}
   labels:
     {{- include "keto.labels" . | nindent 4 }}
   annotations:

--- a/helm/charts/kratos-selfservice-ui-node/templates/ingress.yaml
+++ b/helm/charts/kratos-selfservice-ui-node/templates/ingress.yaml
@@ -8,7 +8,9 @@ apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: {{ $fullName }}
+  {{- if .Release.Namespace }}
   namespace: {{ .Release.Namespace }}
+  {{- end }}
   labels:
     {{- include "kratos-selfservice-ui-node.labels" . | nindent 4 }}
   {{- with .Values.ingress.annotations }}

--- a/helm/charts/kratos-selfservice-ui-node/templates/tests/test-connection.yaml
+++ b/helm/charts/kratos-selfservice-ui-node/templates/tests/test-connection.yaml
@@ -2,8 +2,11 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: "{{ include "kratos-selfservice-ui-node.fullname" . }}-test-connection"
+  {{- if .Release.Namespace }}
+  namespace: {{ .Release.Namespace }}
+  {{- end }}
   labels:
-{{ include "kratos-selfservice-ui-node.labels" . | indent 4 }}
+    {{ include "kratos-selfservice-ui-node.labels" . | indent 4 }}
   annotations:
     "helm.sh/hook": test-success
 spec:

--- a/helm/charts/kratos-selfservice-ui-node/templates/tests/test-connection.yaml
+++ b/helm/charts/kratos-selfservice-ui-node/templates/tests/test-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   {{- end }}
   labels:
-    {{ include "kratos-selfservice-ui-node.labels" . | indent 4 }}
+{{ include "kratos-selfservice-ui-node.labels" . | indent 4 }}
   annotations:
     "helm.sh/hook": test-success
 spec:

--- a/helm/charts/kratos/templates/configmap-config.yaml
+++ b/helm/charts/kratos/templates/configmap-config.yaml
@@ -3,7 +3,9 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "kratos.fullname" . }}-config
+  {{- if .Release.Namespace }}
   namespace: {{ .Release.Namespace }}
+  {{- end }}
   labels:
     {{- include "kratos.labels" . | nindent 4 }}
   annotations:

--- a/helm/charts/kratos/templates/configmap-migrate.yaml
+++ b/helm/charts/kratos/templates/configmap-migrate.yaml
@@ -3,7 +3,9 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "kratos.fullname" . }}-migrate
+  {{- if .Release.Namespace }}
   namespace: {{ .Release.Namespace }}
+  {{- end }}
   labels:
     {{- include "kratos.labels" . | nindent 4 }}
   annotations:

--- a/helm/charts/kratos/templates/ingress-admin.yaml
+++ b/helm/charts/kratos/templates/ingress-admin.yaml
@@ -8,7 +8,9 @@ apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: {{ $fullName }}-admin
+  {{- if .Release.Namespace }}
   namespace: {{ .Release.Namespace }}
+  {{- end }}
   labels:
     {{- include "kratos.labels" . | nindent 4 }}
   {{- with .Values.ingress.admin.annotations }}

--- a/helm/charts/kratos/templates/ingress-public.yaml
+++ b/helm/charts/kratos/templates/ingress-public.yaml
@@ -8,7 +8,9 @@ apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: {{ $fullName }}-public
+  {{- if .Release.Namespace }}
   namespace: {{ .Release.Namespace }}
+  {{- end }}
   labels:
     {{- include "kratos.labels" . | nindent 4 }}
   {{- with .Values.ingress.public.annotations }}

--- a/helm/charts/kratos/templates/job-rbac.yaml
+++ b/helm/charts/kratos/templates/job-rbac.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "kratos.job.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kratos.labels" . | nindent 4 }}
   {{- with .Values.job.serviceAccount.annotations }}

--- a/helm/charts/kratos/templates/job-rbac.yaml
+++ b/helm/charts/kratos/templates/job-rbac.yaml
@@ -4,7 +4,9 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "kratos.job.serviceAccountName" . }}
+  {{- if .Release.Namespace }}
   namespace: {{ .Release.Namespace }}
+  {{- end }}
   labels:
     {{- include "kratos.labels" . | nindent 4 }}
   {{- with .Values.job.serviceAccount.annotations }}

--- a/helm/charts/kratos/templates/rbac-watcher.yaml
+++ b/helm/charts/kratos/templates/rbac-watcher.yaml
@@ -4,6 +4,9 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "kratos.serviceAccountName" . }}-watcher
+  {{- if .Release.Namespace }}
+  namespace: {{ .Release.Namespace }}
+  {{- end }}
   labels:
     app.kubernetes.io/name: {{ include "kratos.name" . }}-watcher
     app.kubernetes.io/instance: {{ .Release.Name }}
@@ -12,7 +15,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ include "kratos.fullname" . }}-watcher
+  {{- if .Release.Namespace }}
   namespace: {{ .Release.Namespace }}
+  {{- end }}
 rules:
   - apiGroups: ["apps"]
     resources: 
@@ -40,7 +45,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ include "kratos.fullname" . }}-watcher
+  {{- if .Release.Namespace }}
   namespace: {{ .Release.Namespace }}
+  {{- end }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/helm/charts/kratos/templates/rbac.yaml
+++ b/helm/charts/kratos/templates/rbac.yaml
@@ -4,6 +4,9 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "kratos.serviceAccountName" . }}
+  {{- if .Release.Namespace }}
+  namespace: {{ .Release.Namespace }}
+  {{- end }}
   labels:
     {{- include "kratos.labels" . | nindent 4 }}
   {{- with .Values.deployment.serviceAccount.annotations }}

--- a/helm/charts/kratos/templates/secrets.yaml
+++ b/helm/charts/kratos/templates/secrets.yaml
@@ -3,7 +3,9 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "kratos.secretname" . }}
+  {{- if .Release.Namespace }}
   namespace: {{ .Release.Namespace }}
+  {{- end }}
   labels:
 {{ include "kratos.labels" . | indent 4 }}
   annotations:

--- a/helm/charts/kratos/templates/service-admin.yaml
+++ b/helm/charts/kratos/templates/service-admin.yaml
@@ -4,7 +4,9 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "kratos.fullname" . }}-admin
+  {{- if .Release.Namespace }}
   namespace: {{ .Release.Namespace }}
+  {{- end }}
   labels:
     {{- with .Values.service.admin.labels }}
       {{- toYaml . | nindent 4 }}
@@ -31,7 +33,9 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ include "kratos.fullname" . }}-admin
+  {{- if .Release.Namespace }}
   namespace: {{ .Release.Namespace }}
+  {{- end }}
   labels:
     app.kubernetes.io/component: admin
 {{ include "kratos.labels" . | indent 4 }}

--- a/helm/charts/kratos/templates/service-public.yaml
+++ b/helm/charts/kratos/templates/service-public.yaml
@@ -3,7 +3,9 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "kratos.fullname" . }}-public
+  {{- if .Release.Namespace }}
   namespace: {{ .Release.Namespace }}
+  {{- end }}
   labels:
     {{- with .Values.service.public.labels }}
       {{- toYaml . | nindent 4 }}

--- a/helm/charts/kratos/templates/tests/test-connection.yaml
+++ b/helm/charts/kratos/templates/tests/test-connection.yaml
@@ -2,8 +2,11 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: "{{ include "kratos.fullname" . }}-test-connection"
+  {{- if .Release.Namespace }}
+  namespace: {{ .Release.Namespace }}
+  {{- end }}
   labels:
-{{ include "kratos.labels" . | indent 4 }}
+    {{ include "kratos.labels" . | indent 4 }}
   annotations:
     "helm.sh/hook": test-success
 spec:

--- a/helm/charts/kratos/templates/tests/test-connection.yaml
+++ b/helm/charts/kratos/templates/tests/test-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   {{- end }}
   labels:
-    {{ include "kratos.labels" . | indent 4 }}
+{{ include "kratos.labels" . | indent 4 }}
   annotations:
     "helm.sh/hook": test-success
 spec:

--- a/helm/charts/oathkeeper/templates/ingress-api.yaml
+++ b/helm/charts/oathkeeper/templates/ingress-api.yaml
@@ -8,7 +8,9 @@ apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: {{ $fullName }}-api
+  {{- if .Release.Namespace }}
   namespace: {{ .Release.Namespace }}
+  {{- end }}
   labels:
     {{- include "oathkeeper.labels" . | nindent 4 }}
   {{- with .Values.ingress.api.annotations }}

--- a/helm/charts/oathkeeper/templates/ingress-proxy.yaml
+++ b/helm/charts/oathkeeper/templates/ingress-proxy.yaml
@@ -8,7 +8,9 @@ apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: {{ $fullName }}-proxy
+  {{- if .Release.Namespace }}
   namespace: {{ .Release.Namespace }}
+  {{- end }}
   labels:
     {{- include "oathkeeper.labels" . | nindent 4 }}
   annotations:

--- a/helm/charts/oathkeeper/templates/rbac.yaml
+++ b/helm/charts/oathkeeper/templates/rbac.yaml
@@ -4,6 +4,9 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "oathkeeper.serviceAccountName" . }}
+  {{- if .Release.Namespace }}
+  namespace: {{ .Release.Namespace }}
+  {{- end }}
   labels:
     {{- include "oathkeeper.labels" . | nindent 4 }}
   {{- with .Values.deployment.serviceAccount.annotations }}

--- a/helm/charts/oathkeeper/templates/secrets.yaml
+++ b/helm/charts/oathkeeper/templates/secrets.yaml
@@ -3,7 +3,9 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "oathkeeper.secretname" . }}
+  {{- if .Release.Namespace }}
   namespace: {{ .Release.Namespace }}
+  {{- end }}
   labels:
 {{ include "oathkeeper.labels" . | indent 4 }}
   annotations:

--- a/helm/charts/oathkeeper/templates/service-metrics.yaml
+++ b/helm/charts/oathkeeper/templates/service-metrics.yaml
@@ -33,7 +33,9 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ include "oathkeeper.fullname" . }}-metrics
+  {{- if .Release.Namespace }}
   namespace: {{ .Release.Namespace }}
+  {{- end }}
   labels:
     app.kubernetes.io/component: metrics
 {{ include "oathkeeper.labels" . | indent 4 }}

--- a/helm/charts/oathkeeper/templates/tests/test-connection.yaml
+++ b/helm/charts/oathkeeper/templates/tests/test-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   {{- end }}
   labels:
-{{ include "oathkeeper.labels" . | indent 4 }}
+    {{ include "oathkeeper.labels" . | indent 4 }}
   annotations:
     "helm.sh/hook": test-success
 spec:

--- a/helm/charts/oathkeeper/templates/tests/test-connection.yaml
+++ b/helm/charts/oathkeeper/templates/tests/test-connection.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   {{- end }}
   labels:
-    {{ include "oathkeeper.labels" . | indent 4 }}
+{{ include "oathkeeper.labels" . | indent 4 }}
   annotations:
     "helm.sh/hook": test-success
 spec:


### PR DESCRIPTION

When created a repo with Flux to setup a Gitops approach i noticed there were namespace definitions missing in the Helm charts. This caused the deployment to malfunction. 

I also noticed inconsistency in how the `Release.Namespace` was incorporated into the charts. This PR will also fix the inconsistencies.

These changes are backwards compatible with existing deployments. Please incorporate these changes so that people with a Gitops setup can use the Helm charts with confidence.

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md) and signed the CLA.
- [ ] I have referenced an issue containing the design document if my change introduces a new feature.
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security vulnerability. 
      If this pull request addresses a security vulnerability, 
      I confirm that I got approval (please contact [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push the changes.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added the necessary documentation within the code base (if appropriate).

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
