### PR TITLE
docs: fix reference to oathkeeper configuration

### DIFF
--- a/docs/helm/oathkeeper.md
+++ b/docs/helm/oathkeeper.md
@@ -62,10 +62,9 @@ $ helm install -f ./path/to/oathkeeper-config.yaml ory/oathkeeper
 ```
 
 Values such as the proxy / api port will be automatically propagated to the
-service and ingress definitions. The following table lists the configurable
-parameters of the ORY Oathkeeper chart and their default values.
+service and ingress definitions.
 
-For a detailed list of configuration items
+For a detailed list of configuration items look at the [Configuration Reference](https://www.ory.sh/docs/oathkeeper/reference/configuration)
 
 ### JSON Web Key Set for Mutator `id_token`
 

--- a/docs/helm/oathkeeper.md
+++ b/docs/helm/oathkeeper.md
@@ -66,6 +66,7 @@ service and ingress definitions.
 
 For a detailed list of configuration items look at the
 [Configuration Reference](https://www.ory.sh/docs/oathkeeper/reference/configuration)
+[Configuration Reference](https://www.ory.sh/docs/oathkeeper/reference/configuration)
 
 ### JSON Web Key Set for Mutator `id_token`
 

--- a/docs/helm/oathkeeper.md
+++ b/docs/helm/oathkeeper.md
@@ -66,7 +66,6 @@ service and ingress definitions.
 
 For a detailed list of configuration items look at the
 [Configuration Reference](https://www.ory.sh/docs/oathkeeper/reference/configuration)
-[Configuration Reference](https://www.ory.sh/docs/oathkeeper/reference/configuration)
 
 ### JSON Web Key Set for Mutator `id_token`
 

--- a/docs/helm/oathkeeper.md
+++ b/docs/helm/oathkeeper.md
@@ -64,7 +64,8 @@ $ helm install -f ./path/to/oathkeeper-config.yaml ory/oathkeeper
 Values such as the proxy / api port will be automatically propagated to the
 service and ingress definitions.
 
-For a detailed list of configuration items look at the [Configuration Reference](https://www.ory.sh/docs/oathkeeper/reference/configuration)
+For a detailed list of configuration items look at the
+[Configuration Reference](https://www.ory.sh/docs/oathkeeper/reference/configuration)
 
 ### JSON Web Key Set for Mutator `id_token`
 


### PR DESCRIPTION
Fixes a dangling sentence by adding a link to the Oathkeeper configuration.

Also removes a reference to a non-existent table.

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md) and signed the CLA.
- [x] I have referenced an issue containing the design document if my change introduces a new feature.
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security vulnerability. 
      If this pull request addresses a security vulnerability, 
      I confirm that I got approval (please contact [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push the changes.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added the necessary documentation within the code base (if appropriate).
