### PR TITLE
fix: define memory target before cpu in hpa for keto and oathkeeper t…

### DIFF
--- a/helm/charts/keto/templates/hpa.yaml
+++ b/helm/charts/keto/templates/hpa.yaml
@@ -15,17 +15,17 @@ spec:
   minReplicas: {{ $autoscaling.minReplicas }}
   maxReplicas: {{ $autoscaling.maxReplicas }}
   metrics:
-  {{- with $autoscaling.targetCPU}}
-  - type: Resource
-    resource:
-      name: cpu
-      target:
-        {{- toYaml . | nindent 8 }}
-  {{- end }}
   {{- with $autoscaling.targetMemory }}
   - type: Resource
     resource:
       name: memory
+      target:
+        {{- toYaml . | nindent 8 }}
+  {{- end }}
+  {{- with $autoscaling.targetCPU}}
+  - type: Resource
+    resource:
+      name: cpu
       target:
         {{- toYaml . | nindent 8 }}
   {{- end }}

--- a/helm/charts/oathkeeper/templates/hpa-controller.yaml
+++ b/helm/charts/oathkeeper/templates/hpa-controller.yaml
@@ -16,17 +16,17 @@ spec:
   minReplicas: {{ .Values.deployment.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.deployment.autoscaling.maxReplicas }}
   metrics:
-  {{- with .Values.deployment.autoscaling.targetCPU}}
-  - type: Resource
-    resource:
-      name: cpu
-      target:
-        {{- toYaml . | nindent 8 }}
-  {{- end }}
   {{- with .Values.deployment.autoscaling.targetMemory }}
   - type: Resource
     resource:
       name: memory
+      target:
+        {{- toYaml . | nindent 8 }}
+  {{- end }}
+  {{- with .Values.deployment.autoscaling.targetCPU}}
+  - type: Resource
+    resource:
+      name: cpu
       target:
         {{- toYaml . | nindent 8 }}
   {{- end }}


### PR DESCRIPTION
Following this PR: https://github.com/ory/k8s/pull/576 I am adding the fix to the missing components

Because of this https://github.com/kubernetes/kubernetes/issues/74099 argocd see a perpetual diff on hpa for keto and oathkeeper.

By ordering memory target before cpu for keto and oathkeeper hpa, the diff in argocd will disapear without having to setup a ignorediff rule for those hpas.

# Related Issue or Design Document

https://github.com/kubernetes/kubernetes/issues/74099
https://github.com/argoproj/argo-cd/issues/1079

# Checklist

- [x] I have read the [contributing guidelines](https://github.com/ory/k8s/blob/master/CONTRIBUTING.md) and signed the CLA.
- [x] I have referenced an issue containing the design document if my change introduces a new feature.
- [x] I have read the [security policy](https://github.com/ory/k8s/security/policy).
- [x] I confirm that this pull request does not address a security vulnerability.
- [x] If this pull request addresses a security vulnerability,
- [x] I confirm that I got approval (please contact [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push the changes.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added the necessary documentation within the code base (if appropriate).

# Further comments

n/a