### PR TITLE
fix: upgrade hydra-maester chart to support OAuth2Client 'Ready' condition

### DIFF
--- a/helm/charts/hydra-maester/crds/crd-oauth2clients.yaml
+++ b/helm/charts/hydra-maester/crds/crd-oauth2clients.yaml
@@ -1,10 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.9
+    controller-gen.kubebuilder.io/version: v0.5.0
   creationTimestamp: null
   name: oauth2clients.hydra.ory.sh
 spec:
@@ -16,181 +15,236 @@ spec:
     singular: oauth2client
   scope: Namespaced
   versions:
-  - name: v1alpha1
-    schema:
-      openAPIV3Schema:
-        description: OAuth2Client is the Schema for the oauth2clients API
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: OAuth2ClientSpec defines the desired state of OAuth2Client
-            properties:
-              allowedCorsOrigins:
-                description: AllowedCorsOrigins is an array of allowed CORS origins
-                items:
-                  description: RedirectURI represents a redirect URI for the client
-                  pattern: \w+:/?/?[^\s]+
-                  type: string
-                type: array
-              audience:
-                description: Audience is a whitelist defining the audiences this client
-                  is allowed to request tokens for
-                items:
-                  type: string
-                type: array
-              clientName:
-                description: ClientName is the human-readable string name of the client
-                  to be presented to the end-user during authorization.
-                type: string
-              grantTypes:
-                description: GrantTypes is an array of grant types the client is allowed
-                  to use.
-                items:
-                  description: GrantType represents an OAuth 2.0 grant type
-                  enum:
-                  - client_credentials
-                  - authorization_code
-                  - implicit
-                  - refresh_token
-                  type: string
-                maxItems: 4
-                minItems: 1
-                type: array
-              hydraAdmin:
-                description: HydraAdmin is the optional configuration to use for managing
-                  this client
-                properties:
-                  endpoint:
-                    description: Endpoint is the endpoint for the hydra instance on
-                      which to set up the client. This value will override the value
-                      provided to `--endpoint` (defaults to `"/clients"` in the application)
-                    pattern: (^$|^/.*)
-                    type: string
-                  forwardedProto:
-                    description: ForwardedProto overrides the `--forwarded-proto`
-                      flag. The value "off" will force this to be off even if `--forwarded-proto`
-                      is specified
-                    pattern: (^$|https?|off)
-                    type: string
-                  port:
-                    description: Port is the port for the hydra instance on which
-                      to set up the client. This value will override the value provided
-                      to `--hydra-port`
-                    maximum: 65535
-                    type: integer
-                  url:
-                    description: URL is the URL for the hydra instance on which to
-                      set up the client. This value will override the value provided
-                      to `--hydra-url`
-                    maxLength: 64
-                    pattern: (^$|^https?://.*)
-                    type: string
-                type: object
-              metadata:
-                description: Metadata is abritrary data
-                nullable: true
-                type: object
-                x-kubernetes-preserve-unknown-fields: true
-              postLogoutRedirectUris:
-                description: PostLogoutRedirectURIs is an array of the post logout
-                  redirect URIs allowed for the application
-                items:
-                  description: RedirectURI represents a redirect URI for the client
-                  pattern: \w+:/?/?[^\s]+
-                  type: string
-                type: array
-              redirectUris:
-                description: RedirectURIs is an array of the redirect URIs allowed
-                  for the application
-                items:
-                  description: RedirectURI represents a redirect URI for the client
-                  pattern: \w+:/?/?[^\s]+
-                  type: string
-                type: array
-              responseTypes:
-                description: ResponseTypes is an array of the OAuth 2.0 response type
-                  strings that the client can use at the authorization endpoint.
-                items:
-                  description: ResponseType represents an OAuth 2.0 response type
-                    strings
-                  enum:
-                  - id_token
-                  - code
-                  - token
-                  type: string
-                maxItems: 3
-                minItems: 1
-                type: array
-              scope:
-                description: Scope is a string containing a space-separated list of
-                  scope values (as described in Section 3.3 of OAuth 2.0 [RFC6749])
-                  that the client can use when requesting access tokens.
-                pattern: ([a-zA-Z0-9\.\*]+\s?)+
-                type: string
-              secretName:
-                description: SecretName points to the K8s secret that contains this
-                  client's ID and password
-                maxLength: 253
-                minLength: 1
-                pattern: '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*'
-                type: string
-              tokenEndpointAuthMethod:
-                allOf:
-                - enum:
-                  - client_secret_basic
-                  - client_secret_post
-                  - private_key_jwt
-                  - none
-                - enum:
-                  - client_secret_basic
-                  - client_secret_post
-                  - private_key_jwt
-                  - none
-                description: Indication which authentication method shoud be used
-                  for the token endpoint
-                type: string
-            required:
-            - grantTypes
-            - scope
-            - secretName
-            type: object
-          status:
-            description: OAuth2ClientStatus defines the observed state of OAuth2Client
-            properties:
-              observedGeneration:
-                description: ObservedGeneration represents the most recent generation
-                  observed by the daemon set controller.
-                format: int64
-                type: integer
-              reconciliationError:
-                description: ReconciliationError represents an error that occurred
-                  during the reconciliation process
-                properties:
+    - name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: OAuth2Client is the Schema for the oauth2clients API
+          properties:
+            apiVersion:
+              description:
+                "APIVersion defines the versioned schema of this representation
+                of an object. Servers should convert recognized schemas to the
+                latest internal value, and may reject unrecognized values. More
+                info:
+                https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources"
+              type: string
+            kind:
+              description:
+                "Kind is a string value representing the REST resource this
+                object represents. Servers may infer this from the endpoint the
+                client submits requests to. Cannot be updated. In CamelCase.
+                More info:
+                https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"
+              type: string
+            metadata:
+              type: object
+            spec:
+              description:
+                OAuth2ClientSpec defines the desired state of OAuth2Client
+              properties:
+                allowedCorsOrigins:
                   description:
-                    description: Description is the description of the reconciliation
-                      error
+                    AllowedCorsOrigins is an array of allowed CORS origins
+                  items:
+                    description:
+                      RedirectURI represents a redirect URI for the client
+                    pattern: \w+:/?/?[^\s]+
                     type: string
-                  statusCode:
-                    description: Code is the status code of the reconciliation error
+                  type: array
+                audience:
+                  description:
+                    Audience is a whitelist defining the audiences this client
+                    is allowed to request tokens for
+                  items:
                     type: string
-                type: object
-            type: object
-        type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
+                  type: array
+                clientName:
+                  description:
+                    ClientName is the human-readable string name of the client
+                    to be presented to the end-user during authorization.
+                  type: string
+                grantTypes:
+                  description:
+                    GrantTypes is an array of grant types the client is allowed
+                    to use.
+                  items:
+                    description: GrantType represents an OAuth 2.0 grant type
+                    enum:
+                      - client_credentials
+                      - authorization_code
+                      - implicit
+                      - refresh_token
+                    type: string
+                  maxItems: 4
+                  minItems: 1
+                  type: array
+                hydraAdmin:
+                  description:
+                    HydraAdmin is the optional configuration to use for managing
+                    this client
+                  properties:
+                    endpoint:
+                      description:
+                        Endpoint is the endpoint for the hydra instance on which
+                        to set up the client. This value will override the value
+                        provided to `--endpoint` (defaults to `"/clients"` in
+                        the application)
+                      pattern: (^$|^/.*)
+                      type: string
+                    forwardedProto:
+                      description:
+                        ForwardedProto overrides the `--forwarded-proto` flag.
+                        The value "off" will force this to be off even if
+                        `--forwarded-proto` is specified
+                      pattern: (^$|https?|off)
+                      type: string
+                    port:
+                      description:
+                        Port is the port for the hydra instance on which to set
+                        up the client. This value will override the value
+                        provided to `--hydra-port`
+                      maximum: 65535
+                      type: integer
+                    url:
+                      description:
+                        URL is the URL for the hydra instance on which to set up
+                        the client. This value will override the value provided
+                        to `--hydra-url`
+                      maxLength: 64
+                      pattern: (^$|^https?://.*)
+                      type: string
+                  type: object
+                metadata:
+                  description: Metadata is abritrary data
+                  nullable: true
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+                postLogoutRedirectUris:
+                  description:
+                    PostLogoutRedirectURIs is an array of the post logout
+                    redirect URIs allowed for the application
+                  items:
+                    description:
+                      RedirectURI represents a redirect URI for the client
+                    pattern: \w+:/?/?[^\s]+
+                    type: string
+                  type: array
+                redirectUris:
+                  description:
+                    RedirectURIs is an array of the redirect URIs allowed for
+                    the application
+                  items:
+                    description:
+                      RedirectURI represents a redirect URI for the client
+                    pattern: \w+:/?/?[^\s]+
+                    type: string
+                  type: array
+                responseTypes:
+                  description:
+                    ResponseTypes is an array of the OAuth 2.0 response type
+                    strings that the client can use at the authorization
+                    endpoint.
+                  items:
+                    description:
+                      ResponseType represents an OAuth 2.0 response type strings
+                    enum:
+                      - id_token
+                      - code
+                      - token
+                      - code token
+                      - code id_token
+                      - id_token token
+                      - code id_token token
+                    type: string
+                  maxItems: 3
+                  minItems: 1
+                  type: array
+                scope:
+                  description:
+                    Scope is a string containing a space-separated list of scope
+                    values (as described in Section 3.3 of OAuth 2.0 [RFC6749])
+                    that the client can use when requesting access tokens.
+                  pattern: ([a-zA-Z0-9\.\*]+\s?)+
+                  type: string
+                secretName:
+                  description:
+                    SecretName points to the K8s secret that contains this
+                    client's ID and password
+                  maxLength: 253
+                  minLength: 1
+                  pattern: '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*'
+                  type: string
+                tokenEndpointAuthMethod:
+                  allOf:
+                    - enum:
+                        - client_secret_basic
+                        - client_secret_post
+                        - private_key_jwt
+                        - none
+                    - enum:
+                        - client_secret_basic
+                        - client_secret_post
+                        - private_key_jwt
+                        - none
+                  description:
+                    Indication which authentication method shoud be used for the
+                    token endpoint
+                  type: string
+              required:
+                - grantTypes
+                - scope
+                - secretName
+              type: object
+            status:
+              description:
+                OAuth2ClientStatus defines the observed state of OAuth2Client
+              properties:
+                conditions:
+                  items:
+                    description:
+                      OAuth2ClientCondition contains condition information for
+                      an OAuth2Client
+                    properties:
+                      status:
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        type: string
+                    required:
+                      - status
+                      - type
+                    type: object
+                  type: array
+                observedGeneration:
+                  description:
+                    ObservedGeneration represents the most recent generation
+                    observed by the daemon set controller.
+                  format: int64
+                  type: integer
+                reconciliationError:
+                  description:
+                    ReconciliationError represents an error that occurred during
+                    the reconciliation process
+                  properties:
+                    description:
+                      description:
+                        Description is the description of the reconciliation
+                        error
+                      type: string
+                    statusCode:
+                      description:
+                        Code is the status code of the reconciliation error
+                      type: string
+                  type: object
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
 status:
   acceptedNames:
     kind: ""

--- a/helm/charts/hydra-maester/values.yaml
+++ b/helm/charts/hydra-maester/values.yaml
@@ -11,7 +11,7 @@ image:
   # -- Ory Hydra-maester image
   repository: oryd/hydra-maester
   # -- Ory Hydra-maester version
-  tag: v0.0.25
+  tag: v0.0.27
   # -- Image pull policy
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.

This text will be included in the changelog. If applicable, include links to documentation or pieces of code.
If your change includes breaking changes please add a code block documenting the breaking change:

```
BREAKING CHANGES: This patch changes the behavior of configuration item `foo` to do bar. To keep the existing
behavior please do baz.
```
-->
Upgrade hydra-maester to v0.0.27 which adds Ready condition to OAuth2ClientStatus. This allows k8s clients with support for status conditions to determine if the client has been synchronized with hydra and the corresponding secret for an OAuth2Client is ready to be read.

## Related Issue or Design Document

<!--
If this pull request

1. is a fix for a known bug, link the issue where the bug was reported in the format of `#1234`;
2. is a fix for a previously unknown bug, explain the bug and how to reproduce it in this pull request;
3. implements a new feature, link the issue containing the design document in the format of `#1234`;
4. improves the documentation, no issue reference is required.

Pull requests introducing new features, which do not have a design document linked are more likely to be rejected and take on average 2-8 weeks longer to
get merged.

You can discuss changes with maintainers either in the Github Discussions in this repository or
join the [Ory Chat](https://www.ory.sh/chat).
-->

hydra-maester PR: https://github.com/ory/hydra-maester/pull/122

This change fixes an issue I was having when trying to use hydra-maester with OAuth2Clients in terraform. Since this is a custom resource I was using the kubernetes_manifest resource, and I was also using terraform to extract the client credentials from the k8s secret. However, this was not working because terraform attempts to read the secret immediately after it finishes creating the OAuth2Client, and when the secret doesn't exist yet (which happens like 75%) of the time, the terraform apply fails. The kubernetes_manifest has built in support for "conditions" which are a k8s concept that help controllers and clients communicate. I can tell terraform to wait for the Ready condition to be True and this will stop terraform from trying to read the secret too early. Controllers like cert-manager use a similar technique.

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md) and signed the CLA.
- [x] I have referenced an issue containing the design document if my change introduces a new feature.
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security vulnerability. 
      If this pull request addresses a security vulnerability, 
      I confirm that I got approval (please contact [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push the changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added the necessary documentation within the code base (if appropriate).

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
 The change is not as large as it looks. All I did was the `status.conditions` field to OAuth2Client CRD. Everything else is essentially whitespace changes, probably resulting from the controller-gen version bump.