### PR TITLE
fix: remove revisionHistoryLimit from statefulset-mail.yaml

### DIFF
--- a/helm/charts/kratos/templates/statefulset-mail.yaml
+++ b/helm/charts/kratos/templates/statefulset-mail.yaml
@@ -32,7 +32,6 @@ spec:
       app.kubernetes.io/instance: {{ .Release.Name }}
   serviceName: {{ include "kratos.fullname" . }}-courier
   replicas: 1
-  revisionHistoryLimit: {{ .Values.statefulSet.revisionHistoryLimit }}
   template:
     metadata:
       labels:
@@ -58,7 +57,7 @@ spec:
           imagePullPolicy: {{ include "kratos.imagePullPolicy" . }}
           args:
             - courier
-            - watch 
+            - watch
             - --config
             - /etc/config/kratos.yaml
             {{- if .Values.statefulSet.extraArgs }}


### PR DESCRIPTION
remove not allowed  `revisionHistoryLimit` property from statefulset-mail.yaml

causing Helm error:

```
Helm upgrade failed: cannot patch "kratos-courier" with kind StatefulSet: StatefulSet.apps "kratos-courier" is invalid: spec: Forbidden: updates to statefulset spec for fields other than 'replicas', 'ordinals', 'template', 'updateStrategy', 'persistentVolumeClaimRetentionPolicy' and 'minReadySeconds' are forbidden
```

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md) and signed the CLA.
- [x] I have referenced an issue containing the design document if my change introduces a new feature.
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security vulnerability. 
      If this pull request addresses a security vulnerability, 
      I confirm that I got approval (please contact [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push the changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added the necessary documentation within the code base (if appropriate).

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
