### PR TITLE
feat: added configuration for TLS enabled hydra admin services

### DIFF
--- a/hacks/values/hydra-maester.yaml
+++ b/hacks/values/hydra-maester.yaml
@@ -10,3 +10,10 @@ deployment:
   serviceAccount:
     annotations:
       ory.sh/pod_annotation: hydra-maester
+  extraVolumes:
+    - name: "test-volume"
+      emptyDir:
+        sizeLimit: 1Mi
+  extraVolumeMounts:
+    - name: "test-volume"
+      mountPath: /test-volume

--- a/helm/charts/hydra-maester/templates/deployment.yaml
+++ b/helm/charts/hydra-maester/templates/deployment.yaml
@@ -52,7 +52,7 @@ spec:
             - /manager
           args:
             - --metrics-addr=127.0.0.1:8080
-            - --hydra-url={{ .Values.adminService.scheme | default "http" }}://{{ .Values.adminService.name | default ( include "hydra-maester.adminService" . ) }}
+            - --hydra-url={{ .Values.adminService.scheme }}://{{ .Values.adminService.name | default ( include "hydra-maester.adminService" . ) }}
             - --hydra-port={{ .Values.adminService.port | default 4445 }}
             {{- with .Values.adminService.endpoint }}
             - --endpoint={{ . }}
@@ -67,7 +67,7 @@ spec:
             - --sync-period={{ .Values.deployment.args.syncPeriod }}
             {{- end }}
             {{- if .Values.adminService.insecureSkipVerify }}
-            - --insecure-skip-verify=true
+            - --insecure-skip-verify={{ .Values.adminService.insecureSkipVerify }}
             {{- end}}
             {{- if .Values.adminService.tlsTrustStorePath }}
             - --tls-trust-store={{ .Values.adminService.tlsTrustStorePath }}

--- a/helm/charts/hydra-maester/templates/deployment.yaml
+++ b/helm/charts/hydra-maester/templates/deployment.yaml
@@ -1,3 +1,6 @@
+{{- if and (ne .Values.adminService.scheme "http") (ne .Values.adminService.scheme "https") -}}
+{{ fail "invalid scheme: must be http or https" }}
+{{- end -}}
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -52,8 +55,8 @@ spec:
             - /manager
           args:
             - --metrics-addr=127.0.0.1:8080
-            - --hydra-url={{ .Values.adminService.scheme }}://{{ .Values.adminService.name | default ( include "hydra-maester.adminService" . ) }}
-            - --hydra-port={{ .Values.adminService.port | default 4445 }}
+            - --hydra-url={{ required "scheme is required" .Values.adminService.scheme }}://{{ .Values.adminService.name | default ( include "hydra-maester.adminService" . ) }}
+            - --hydra-port={{ .Values.adminService.port }}
             {{- with .Values.adminService.endpoint }}
             - --endpoint={{ . }}
             {{- end }}

--- a/helm/charts/hydra-maester/templates/deployment.yaml
+++ b/helm/charts/hydra-maester/templates/deployment.yaml
@@ -40,6 +40,10 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      volumes:
+        {{- if .Values.deployment.extraVolumes }}
+          {{- toYaml .Values.deployment.extraVolumes | nindent 8 }}
+        {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
@@ -48,7 +52,7 @@ spec:
             - /manager
           args:
             - --metrics-addr=127.0.0.1:8080
-            - --hydra-url=http://{{ .Values.adminService.name | default ( include "hydra-maester.adminService" . ) }}
+            - --hydra-url={{ .Values.adminService.scheme | default "http" }}://{{ .Values.adminService.name | default ( include "hydra-maester.adminService" . ) }}
             - --hydra-port={{ .Values.adminService.port | default 4445 }}
             {{- with .Values.adminService.endpoint }}
             - --endpoint={{ . }}
@@ -61,6 +65,16 @@ spec:
             {{- end }}
             {{- if .Values.deployment.args.syncPeriod }}
             - --sync-period={{ .Values.deployment.args.syncPeriod }}
+            {{- end }}
+            {{- if .Values.adminService.insecureSkipVerify }}
+            - --insecure-skip-verify=true
+            {{- end}}
+            {{- if .Values.adminService.tlsTrustStorePath }}
+            - --tls-trust-store={{ .Values.adminService.tlsTrustStorePath }}
+            {{- end }}
+          volumeMounts:
+            {{- if .Values.deployment.extraVolumeMounts }}
+              {{- toYaml .Values.deployment.extraVolumeMounts | nindent 12 }}
             {{- end }}
           resources:
             {{- toYaml .Values.deployment.resources | nindent 12 }}

--- a/helm/charts/hydra-maester/values.yaml
+++ b/helm/charts/hydra-maester/values.yaml
@@ -33,11 +33,11 @@ adminService:
   # `/admin/clients` for Hydra 2.x
   endpoint: /admin/clients
   # -- Scheme used by Hydra client endpoint. May be "http" or "https"
-  scheme:
+  scheme: http
   # -- TLS ca-cert path for hydra client
-  tlsTrustStorePath:
+  tlsTrustStorePath: ""
   # -- Skip http client insecure verification
-  insecureSkipVerify:
+  insecureSkipVerify: false
 
 forwardedProto:
 

--- a/helm/charts/hydra-maester/values.yaml
+++ b/helm/charts/hydra-maester/values.yaml
@@ -32,6 +32,12 @@ adminService:
   # -- Set the clients endpoint, should be `/clients` for Hydra 1.x and
   # `/admin/clients` for Hydra 2.x
   endpoint: /admin/clients
+  # -- Scheme used by Hydra client endpoint. May be "http" or "https"
+  scheme:
+  # -- TLS ca-cert path for hydra client
+  tlsTrustStorePath:
+  # -- Skip http client insecure verification
+  insecureSkipVerify:
 
 forwardedProto:
 
@@ -48,6 +54,16 @@ deployment:
     # requests:
     #   cpu: 100m
     #   memory: 20Mi
+
+  # -- If you want to mount external volume
+  extraVolumes: []
+  # - name: my-volume
+  #   secret:
+  #     secretName: my-secret
+  extraVolumeMounts: []
+  # - name: my-volume
+  #   mountPath: /etc/secrets/my-secret
+  #   readOnly: true
 
   # -- Default security context
   securityContext:

--- a/helm/charts/hydra-maester/values.yaml
+++ b/helm/charts/hydra-maester/values.yaml
@@ -28,7 +28,7 @@ adminService:
   # -- Service name
   name:
   # -- Service port
-  port:
+  port: 4445
   # -- Set the clients endpoint, should be `/clients` for Hydra 1.x and
   # `/admin/clients` for Hydra 2.x
   endpoint: /admin/clients


### PR DESCRIPTION
This pull request adds the ability to configure hydra-maester to point to a hydra admin endpoint that has TLS enabled. Previous to this PR, "http" was hard-coded in the admin host, causing HTTP 400 responses when talking to a hydra admin endpoint with TLS enabled. Furthermore, this PR adds the ability to add volume/volumeMounts to the deployment to add CA certs. 

This simply adds in a few missing command line options from hydra-maester.

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md) and signed the CLA.
- [ ] I have referenced an issue containing the design document if my change introduces a new feature.
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security vulnerability. 
      If this pull request addresses a security vulnerability, 
      I confirm that I got approval (please contact [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push the changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added the necessary documentation within the code base (if appropriate).

