### PR TITLE
feat: added priorityClassName to all charts

### DIFF
--- a/hacks/values/hydra.yaml
+++ b/hacks/values/hydra.yaml
@@ -40,6 +40,8 @@ janitor:
   podSecurityContext:
     runAsNonRoot: true
 
+priorityClassName: "system-cluster-critical"
+
 deployment:
   autoscaling:
     enabled: true

--- a/hacks/values/keto.yaml
+++ b/hacks/values/keto.yaml
@@ -11,6 +11,7 @@ ingress:
     enabled: true
   write:
     enabled: true
+priorityClassName: "system-cluster-critical"
 deployment:
   autoscaling:
     enabled: true

--- a/hacks/values/kratos.yaml
+++ b/hacks/values/kratos.yaml
@@ -246,6 +246,7 @@ deployment:
     periodSeconds: 10
     successThreshold: 1
     timeoutSeconds: 1
+  priorityClassName: "system-cluster-critical"
 
   environmentSecretsName: env-secrets
 
@@ -259,6 +260,7 @@ statefulSet:
     annotations:
       ory.sh/pod_annotation: kratos_courier
   revisionHistoryLimit: 10
+  priorityClassName: "system-cluster-critical"
 
 job:
   extraEnv:

--- a/hacks/values/oathkeeper-maester.yaml
+++ b/hacks/values/oathkeeper-maester.yaml
@@ -1,5 +1,6 @@
 ---
 # singleNamespaceMode: true
+priorityClassName: "system-cluster-critical"
 deployment:
   podMetadata:
     labels:

--- a/hacks/values/oathkeeper.yaml
+++ b/hacks/values/oathkeeper.yaml
@@ -28,6 +28,7 @@ ingress:
       kubernetes.io/tls-acme: "true"
   api:
     enabled: true
+priorityClassName: "system-cluster-critical"
 deployment:
   extraInitContainers: |
     - name: "hello-world"

--- a/helm/charts/hydra/values.yaml
+++ b/helm/charts/hydra/values.yaml
@@ -18,7 +18,7 @@ fullnameOverride: ""
 
 # -- Pod priority
 # https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/
-# priorityClassName: ""
+priorityClassName: ""
 
 # -- Configures the Kubernetes service
 service:

--- a/helm/charts/keto/templates/deployment.yaml
+++ b/helm/charts/keto/templates/deployment.yaml
@@ -202,6 +202,9 @@ spec:
       {{- with $extraVolumes }}
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}
       {{- with $nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/helm/charts/keto/values.yaml
+++ b/helm/charts/keto/values.yaml
@@ -17,6 +17,10 @@ imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 
+# -- Pod priority
+# https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/
+priorityClassName: ""
+
 serviceAccount:
   # -- Specifies whether a service account should be created
   create: true

--- a/helm/charts/kratos/templates/deployment-kratos.yaml
+++ b/helm/charts/kratos/templates/deployment-kratos.yaml
@@ -241,6 +241,9 @@ spec:
         {{- if .Values.deployment.extraContainers }}
           {{- tpl .Values.deployment.extraContainers . | nindent 8 }}
         {{- end }}
+      {{- with .Values.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}
       {{- with .Values.deployment.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/helm/charts/kratos/templates/statefulset-mail.yaml
+++ b/helm/charts/kratos/templates/statefulset-mail.yaml
@@ -150,6 +150,9 @@ spec:
             name: {{ include "kratos.fullname" $root }}-template-{{ $method | kebabcase }}-{{ $result }}
         {{- end }}
         {{- end }}
+      {{- with .Values.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}
       {{- with .Values.statefulSet.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/helm/charts/kratos/values.yaml
+++ b/helm/charts/kratos/values.yaml
@@ -288,6 +288,10 @@ deployment:
   #    cpu: 100m
   #  memory: 128Mi
 
+  # -- Pod priority
+  # https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/
+  priorityClassName: ""
+
   # -- Node labels for pod assignment.
   nodeSelector: {}
   # If you do want to specify node labels, uncomment the following
@@ -424,6 +428,10 @@ statefulSet:
   #      If you do want to specify additional labels, uncomment the following
   #      lines, adjust them as necessary, and remove the curly braces after 'labels:'.
   #      e.g.  type: app
+
+  # -- Pod priority
+  # https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/
+  priorityClassName: ""
 
   # -- Node labels for pod assignment.
   nodeSelector: {}

--- a/helm/charts/oathkeeper-maester/templates/deployment.yaml
+++ b/helm/charts/oathkeeper-maester/templates/deployment.yaml
@@ -83,6 +83,9 @@ spec:
       restartPolicy: Always
       securityContext: {}
       terminationGracePeriodSeconds: 10
+      {{- with .Values.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}
       nodeSelector:
       {{- with .Values.deployment.nodeSelector }}
         {{- toYaml . | nindent 8 }}

--- a/helm/charts/oathkeeper-maester/values.yaml
+++ b/helm/charts/oathkeeper-maester/values.yaml
@@ -58,6 +58,10 @@ deployment:
     allowPrivilegeEscalation: false
     privileged: false
 
+  # -- Pod priority
+  # https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/
+  priorityClassName: ""
+
   # -- Node labels for pod assignment.
   nodeSelector: {}
   # If you do want to specify node labels, uncomment the following

--- a/helm/charts/oathkeeper/templates/deployment-controller.yaml
+++ b/helm/charts/oathkeeper/templates/deployment-controller.yaml
@@ -164,6 +164,9 @@ spec:
         {{- if .Values.deployment.extraContainers }}
           {{- tpl .Values.deployment.extraContainers . | nindent 8 }}
         {{- end }}
+      {{- with .Values.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}
       {{- with .Values.deployment.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/helm/charts/oathkeeper/values.yaml
+++ b/helm/charts/oathkeeper/values.yaml
@@ -29,6 +29,10 @@ sidecar:
     tag: v0.1.2
   envs: {}
 
+# -- Pod priority
+# https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/
+priorityClassName: ""
+
 # -- Image pull secrets
 imagePullSecrets: []
 # -- Chart name override


### PR DESCRIPTION
At the moment, only the hydra and hydra-maester charts allow configuring the priorityClassName. This pull request introduces this configuration option to the other charts as well.

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md) and signed the CLA.
- [ ] I have referenced an issue containing the design document if my change introduces a new feature.
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security vulnerability. 
      If this pull request addresses a security vulnerability, 
      I confirm that I got approval (please contact [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push the changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added the necessary documentation within the code base (if appropriate).