### PR TITLE
fix: disable monitoring.coreos.com/v1 api check

### DIFF
--- a/hacks/helm-validate.sh
+++ b/hacks/helm-validate.sh
@@ -7,4 +7,4 @@ cd "$( dirname "${BASH_SOURCE[0]}" )/.."
 schema_url="https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/"
 k8s_version="1.27.2"
 
-helm kubeconform "./helm/charts/${1}" --strict --schema-location "${schema_url}" -f "hacks/values/${1}.yaml" --kubernetes-version "${k8s_version}" --summary --verbose
+helm kubeconform "./helm/charts/${1}" --strict --schema-location "${schema_url}" --schema-location ./hacks/servicemonitor_v1.json -f "hacks/values/${1}.yaml" --kubernetes-version "${k8s_version}" --summary --verbose

--- a/hacks/servicemonitor_v1.json
+++ b/hacks/servicemonitor_v1.json
@@ -1,0 +1,756 @@
+{
+  "description": "ServiceMonitor defines monitoring for a set of services.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "Specification of desired Service selection for target discovery by Prometheus.",
+      "properties": {
+        "attachMetadata": {
+          "description": "`attachMetadata` defines additional metadata which is added to the discovered targets. \n It requires Prometheus >= v2.37.0.",
+          "properties": {
+            "node": {
+              "description": "When set to true, Prometheus must have the `get` permission on the `Nodes` objects.",
+              "type": "boolean"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "endpoints": {
+          "description": "List of endpoints part of this ServiceMonitor.",
+          "items": {
+            "description": "Endpoint defines an endpoint serving Prometheus metrics to be scraped by Prometheus.",
+            "properties": {
+              "authorization": {
+                "description": "`authorization` configures the Authorization header credentials to use when scraping the target. \n Cannot be set at the same time as `basicAuth`, or `oauth2`.",
+                "properties": {
+                  "credentials": {
+                    "description": "Selects a key of a Secret in the namespace that contains the credentials for authentication.",
+                    "properties": {
+                      "key": {
+                        "description": "The key of the secret to select from.  Must be a valid secret key.",
+                        "type": "string"
+                      },
+                      "name": {
+                        "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                        "type": "string"
+                      },
+                      "optional": {
+                        "description": "Specify whether the Secret or its key must be defined",
+                        "type": "boolean"
+                      }
+                    },
+                    "required": [
+                      "key"
+                    ],
+                    "type": "object",
+                    "x-kubernetes-map-type": "atomic",
+                    "additionalProperties": false
+                  },
+                  "type": {
+                    "description": "Defines the authentication type. The value is case-insensitive. \n \"Basic\" is not a supported value. \n Default: \"Bearer\"",
+                    "type": "string"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "basicAuth": {
+                "description": "`basicAuth` configures the Basic Authentication credentials to use when scraping the target. \n Cannot be set at the same time as `authorization`, or `oauth2`.",
+                "properties": {
+                  "password": {
+                    "description": "`password` specifies a key of a Secret containing the password for authentication.",
+                    "properties": {
+                      "key": {
+                        "description": "The key of the secret to select from.  Must be a valid secret key.",
+                        "type": "string"
+                      },
+                      "name": {
+                        "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                        "type": "string"
+                      },
+                      "optional": {
+                        "description": "Specify whether the Secret or its key must be defined",
+                        "type": "boolean"
+                      }
+                    },
+                    "required": [
+                      "key"
+                    ],
+                    "type": "object",
+                    "x-kubernetes-map-type": "atomic",
+                    "additionalProperties": false
+                  },
+                  "username": {
+                    "description": "`username` specifies a key of a Secret containing the username for authentication.",
+                    "properties": {
+                      "key": {
+                        "description": "The key of the secret to select from.  Must be a valid secret key.",
+                        "type": "string"
+                      },
+                      "name": {
+                        "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                        "type": "string"
+                      },
+                      "optional": {
+                        "description": "Specify whether the Secret or its key must be defined",
+                        "type": "boolean"
+                      }
+                    },
+                    "required": [
+                      "key"
+                    ],
+                    "type": "object",
+                    "x-kubernetes-map-type": "atomic",
+                    "additionalProperties": false
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "bearerTokenFile": {
+                "description": "File to read bearer token for scraping the target. \n Deprecated: use `authorization` instead.",
+                "type": "string"
+              },
+              "bearerTokenSecret": {
+                "description": "`bearerTokenSecret` specifies a key of a Secret containing the bearer token for scraping targets. The secret needs to be in the same namespace as the ServiceMonitor object and readable by the Prometheus Operator. \n Deprecated: use `authorization` instead.",
+                "properties": {
+                  "key": {
+                    "description": "The key of the secret to select from.  Must be a valid secret key.",
+                    "type": "string"
+                  },
+                  "name": {
+                    "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                    "type": "string"
+                  },
+                  "optional": {
+                    "description": "Specify whether the Secret or its key must be defined",
+                    "type": "boolean"
+                  }
+                },
+                "required": [
+                  "key"
+                ],
+                "type": "object",
+                "x-kubernetes-map-type": "atomic",
+                "additionalProperties": false
+              },
+              "enableHttp2": {
+                "description": "`enableHttp2` can be used to disable HTTP2 when scraping the target.",
+                "type": "boolean"
+              },
+              "filterRunning": {
+                "description": "When true, the pods which are not running (e.g. either in Failed or Succeeded state) are dropped during the target discovery. \n If unset, the filtering is enabled. \n More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-phase",
+                "type": "boolean"
+              },
+              "followRedirects": {
+                "description": "`followRedirects` defines whether the scrape requests should follow HTTP 3xx redirects.",
+                "type": "boolean"
+              },
+              "honorLabels": {
+                "description": "When true, `honorLabels` preserves the metric's labels when they collide with the target's labels.",
+                "type": "boolean"
+              },
+              "honorTimestamps": {
+                "description": "`honorTimestamps` controls whether Prometheus preserves the timestamps when exposed by the target.",
+                "type": "boolean"
+              },
+              "interval": {
+                "description": "Interval at which Prometheus scrapes the metrics from the target. \n If empty, Prometheus uses the global scrape interval.",
+                "pattern": "^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$",
+                "type": "string"
+              },
+              "metricRelabelings": {
+                "description": "`metricRelabelings` configures the relabeling rules to apply to the samples before ingestion.",
+                "items": {
+                  "description": "RelabelConfig allows dynamic rewriting of the label set for targets, alerts, scraped samples and remote write samples. \n More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config",
+                  "properties": {
+                    "action": {
+                      "default": "replace",
+                      "description": "Action to perform based on the regex matching. \n `Uppercase` and `Lowercase` actions require Prometheus >= v2.36.0. `DropEqual` and `KeepEqual` actions require Prometheus >= v2.41.0. \n Default: \"Replace\"",
+                      "enum": [
+                        "replace",
+                        "Replace",
+                        "keep",
+                        "Keep",
+                        "drop",
+                        "Drop",
+                        "hashmod",
+                        "HashMod",
+                        "labelmap",
+                        "LabelMap",
+                        "labeldrop",
+                        "LabelDrop",
+                        "labelkeep",
+                        "LabelKeep",
+                        "lowercase",
+                        "Lowercase",
+                        "uppercase",
+                        "Uppercase",
+                        "keepequal",
+                        "KeepEqual",
+                        "dropequal",
+                        "DropEqual"
+                      ],
+                      "type": "string"
+                    },
+                    "modulus": {
+                      "description": "Modulus to take of the hash of the source label values. \n Only applicable when the action is `HashMod`.",
+                      "format": "int64",
+                      "type": "integer"
+                    },
+                    "regex": {
+                      "description": "Regular expression against which the extracted value is matched.",
+                      "type": "string"
+                    },
+                    "replacement": {
+                      "description": "Replacement value against which a Replace action is performed if the regular expression matches. \n Regex capture groups are available.",
+                      "type": "string"
+                    },
+                    "separator": {
+                      "description": "Separator is the string between concatenated SourceLabels.",
+                      "type": "string"
+                    },
+                    "sourceLabels": {
+                      "description": "The source labels select values from existing labels. Their content is concatenated using the configured Separator and matched against the configured regular expression.",
+                      "items": {
+                        "description": "LabelName is a valid Prometheus label name which may only contain ASCII letters, numbers, as well as underscores.",
+                        "pattern": "^[a-zA-Z_][a-zA-Z0-9_]*$",
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "targetLabel": {
+                      "description": "Label to which the resulting string is written in a replacement. \n It is mandatory for `Replace`, `HashMod`, `Lowercase`, `Uppercase`, `KeepEqual` and `DropEqual` actions. \n Regex capture groups are available.",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "type": "array"
+              },
+              "oauth2": {
+                "description": "`oauth2` configures the OAuth2 settings to use when scraping the target. \n It requires Prometheus >= 2.27.0. \n Cannot be set at the same time as `authorization`, or `basicAuth`.",
+                "properties": {
+                  "clientId": {
+                    "description": "`clientId` specifies a key of a Secret or ConfigMap containing the OAuth2 client's ID.",
+                    "properties": {
+                      "configMap": {
+                        "description": "ConfigMap containing data to use for the targets.",
+                        "properties": {
+                          "key": {
+                            "description": "The key to select.",
+                            "type": "string"
+                          },
+                          "name": {
+                            "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                            "type": "string"
+                          },
+                          "optional": {
+                            "description": "Specify whether the ConfigMap or its key must be defined",
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "key"
+                        ],
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      },
+                      "secret": {
+                        "description": "Secret containing data to use for the targets.",
+                        "properties": {
+                          "key": {
+                            "description": "The key of the secret to select from.  Must be a valid secret key.",
+                            "type": "string"
+                          },
+                          "name": {
+                            "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                            "type": "string"
+                          },
+                          "optional": {
+                            "description": "Specify whether the Secret or its key must be defined",
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "key"
+                        ],
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "clientSecret": {
+                    "description": "`clientSecret` specifies a key of a Secret containing the OAuth2 client's secret.",
+                    "properties": {
+                      "key": {
+                        "description": "The key of the secret to select from.  Must be a valid secret key.",
+                        "type": "string"
+                      },
+                      "name": {
+                        "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                        "type": "string"
+                      },
+                      "optional": {
+                        "description": "Specify whether the Secret or its key must be defined",
+                        "type": "boolean"
+                      }
+                    },
+                    "required": [
+                      "key"
+                    ],
+                    "type": "object",
+                    "x-kubernetes-map-type": "atomic",
+                    "additionalProperties": false
+                  },
+                  "endpointParams": {
+                    "additionalProperties": {
+                      "type": "string"
+                    },
+                    "description": "`endpointParams` configures the HTTP parameters to append to the token URL.",
+                    "type": "object"
+                  },
+                  "scopes": {
+                    "description": "`scopes` defines the OAuth2 scopes used for the token request.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "tokenUrl": {
+                    "description": "`tokenURL` configures the URL to fetch the token from.",
+                    "minLength": 1,
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "clientId",
+                  "clientSecret",
+                  "tokenUrl"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "params": {
+                "additionalProperties": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "description": "params define optional HTTP URL parameters.",
+                "type": "object"
+              },
+              "path": {
+                "description": "HTTP path from which to scrape for metrics. \n If empty, Prometheus uses the default value (e.g. `/metrics`).",
+                "type": "string"
+              },
+              "port": {
+                "description": "Name of the Service port which this endpoint refers to. \n It takes precedence over `targetPort`.",
+                "type": "string"
+              },
+              "proxyUrl": {
+                "description": "`proxyURL` configures the HTTP Proxy URL (e.g. \"http://proxyserver:2195\") to go through when scraping the target.",
+                "type": "string"
+              },
+              "relabelings": {
+                "description": "`relabelings` configures the relabeling rules to apply the target's metadata labels. \n The Operator automatically adds relabelings for a few standard Kubernetes fields. \n The original scrape job's name is available via the `__tmp_prometheus_job_name` label. \n More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config",
+                "items": {
+                  "description": "RelabelConfig allows dynamic rewriting of the label set for targets, alerts, scraped samples and remote write samples. \n More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config",
+                  "properties": {
+                    "action": {
+                      "default": "replace",
+                      "description": "Action to perform based on the regex matching. \n `Uppercase` and `Lowercase` actions require Prometheus >= v2.36.0. `DropEqual` and `KeepEqual` actions require Prometheus >= v2.41.0. \n Default: \"Replace\"",
+                      "enum": [
+                        "replace",
+                        "Replace",
+                        "keep",
+                        "Keep",
+                        "drop",
+                        "Drop",
+                        "hashmod",
+                        "HashMod",
+                        "labelmap",
+                        "LabelMap",
+                        "labeldrop",
+                        "LabelDrop",
+                        "labelkeep",
+                        "LabelKeep",
+                        "lowercase",
+                        "Lowercase",
+                        "uppercase",
+                        "Uppercase",
+                        "keepequal",
+                        "KeepEqual",
+                        "dropequal",
+                        "DropEqual"
+                      ],
+                      "type": "string"
+                    },
+                    "modulus": {
+                      "description": "Modulus to take of the hash of the source label values. \n Only applicable when the action is `HashMod`.",
+                      "format": "int64",
+                      "type": "integer"
+                    },
+                    "regex": {
+                      "description": "Regular expression against which the extracted value is matched.",
+                      "type": "string"
+                    },
+                    "replacement": {
+                      "description": "Replacement value against which a Replace action is performed if the regular expression matches. \n Regex capture groups are available.",
+                      "type": "string"
+                    },
+                    "separator": {
+                      "description": "Separator is the string between concatenated SourceLabels.",
+                      "type": "string"
+                    },
+                    "sourceLabels": {
+                      "description": "The source labels select values from existing labels. Their content is concatenated using the configured Separator and matched against the configured regular expression.",
+                      "items": {
+                        "description": "LabelName is a valid Prometheus label name which may only contain ASCII letters, numbers, as well as underscores.",
+                        "pattern": "^[a-zA-Z_][a-zA-Z0-9_]*$",
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "targetLabel": {
+                      "description": "Label to which the resulting string is written in a replacement. \n It is mandatory for `Replace`, `HashMod`, `Lowercase`, `Uppercase`, `KeepEqual` and `DropEqual` actions. \n Regex capture groups are available.",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "type": "array"
+              },
+              "scheme": {
+                "description": "HTTP scheme to use for scraping. \n `http` and `https` are the expected values unless you rewrite the `__scheme__` label via relabeling. \n If empty, Prometheus uses the default value `http`.",
+                "enum": [
+                  "http",
+                  "https"
+                ],
+                "type": "string"
+              },
+              "scrapeTimeout": {
+                "description": "Timeout after which Prometheus considers the scrape to be failed. \n If empty, Prometheus uses the global scrape timeout unless it is less than the target's scrape interval value in which the latter is used.",
+                "pattern": "^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$",
+                "type": "string"
+              },
+              "targetPort": {
+                "anyOf": [
+                  {
+                    "type": "integer"
+                  },
+                  {
+                    "type": "string"
+                  }
+                ],
+                "description": "Name or number of the target port of the `Pod` object behind the Service, the port must be specified with container port property. \n Deprecated: use `port` instead.",
+                "x-kubernetes-int-or-string": true
+              },
+              "tlsConfig": {
+                "description": "TLS configuration to use when scraping the target.",
+                "properties": {
+                  "ca": {
+                    "description": "Certificate authority used when verifying server certificates.",
+                    "properties": {
+                      "configMap": {
+                        "description": "ConfigMap containing data to use for the targets.",
+                        "properties": {
+                          "key": {
+                            "description": "The key to select.",
+                            "type": "string"
+                          },
+                          "name": {
+                            "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                            "type": "string"
+                          },
+                          "optional": {
+                            "description": "Specify whether the ConfigMap or its key must be defined",
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "key"
+                        ],
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      },
+                      "secret": {
+                        "description": "Secret containing data to use for the targets.",
+                        "properties": {
+                          "key": {
+                            "description": "The key of the secret to select from.  Must be a valid secret key.",
+                            "type": "string"
+                          },
+                          "name": {
+                            "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                            "type": "string"
+                          },
+                          "optional": {
+                            "description": "Specify whether the Secret or its key must be defined",
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "key"
+                        ],
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "caFile": {
+                    "description": "Path to the CA cert in the Prometheus container to use for the targets.",
+                    "type": "string"
+                  },
+                  "cert": {
+                    "description": "Client certificate to present when doing client-authentication.",
+                    "properties": {
+                      "configMap": {
+                        "description": "ConfigMap containing data to use for the targets.",
+                        "properties": {
+                          "key": {
+                            "description": "The key to select.",
+                            "type": "string"
+                          },
+                          "name": {
+                            "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                            "type": "string"
+                          },
+                          "optional": {
+                            "description": "Specify whether the ConfigMap or its key must be defined",
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "key"
+                        ],
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      },
+                      "secret": {
+                        "description": "Secret containing data to use for the targets.",
+                        "properties": {
+                          "key": {
+                            "description": "The key of the secret to select from.  Must be a valid secret key.",
+                            "type": "string"
+                          },
+                          "name": {
+                            "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                            "type": "string"
+                          },
+                          "optional": {
+                            "description": "Specify whether the Secret or its key must be defined",
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "key"
+                        ],
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "certFile": {
+                    "description": "Path to the client cert file in the Prometheus container for the targets.",
+                    "type": "string"
+                  },
+                  "insecureSkipVerify": {
+                    "description": "Disable target certificate validation.",
+                    "type": "boolean"
+                  },
+                  "keyFile": {
+                    "description": "Path to the client key file in the Prometheus container for the targets.",
+                    "type": "string"
+                  },
+                  "keySecret": {
+                    "description": "Secret containing the client key file for the targets.",
+                    "properties": {
+                      "key": {
+                        "description": "The key of the secret to select from.  Must be a valid secret key.",
+                        "type": "string"
+                      },
+                      "name": {
+                        "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                        "type": "string"
+                      },
+                      "optional": {
+                        "description": "Specify whether the Secret or its key must be defined",
+                        "type": "boolean"
+                      }
+                    },
+                    "required": [
+                      "key"
+                    ],
+                    "type": "object",
+                    "x-kubernetes-map-type": "atomic",
+                    "additionalProperties": false
+                  },
+                  "serverName": {
+                    "description": "Used to verify the hostname for the targets.",
+                    "type": "string"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "trackTimestampsStaleness": {
+                "description": "`trackTimestampsStaleness` defines whether Prometheus tracks staleness of the metrics that have an explicit timestamp present in scraped data. Has no effect if `honorTimestamps` is false. \n It requires Prometheus >= v2.48.0.",
+                "type": "boolean"
+              }
+            },
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "jobLabel": {
+          "description": "`jobLabel` selects the label from the associated Kubernetes `Service` object which will be used as the `job` label for all metrics. \n For example if `jobLabel` is set to `foo` and the Kubernetes `Service` object is labeled with `foo: bar`, then Prometheus adds the `job=\"bar\"` label to all ingested metrics. \n If the value of this field is empty or if the label doesn't exist for the given Service, the `job` label of the metrics defaults to the name of the associated Kubernetes `Service`.",
+          "type": "string"
+        },
+        "keepDroppedTargets": {
+          "description": "Per-scrape limit on the number of targets dropped by relabeling that will be kept in memory. 0 means no limit. \n It requires Prometheus >= v2.47.0.",
+          "format": "int64",
+          "type": "integer"
+        },
+        "labelLimit": {
+          "description": "Per-scrape limit on number of labels that will be accepted for a sample. \n It requires Prometheus >= v2.27.0.",
+          "format": "int64",
+          "type": "integer"
+        },
+        "labelNameLengthLimit": {
+          "description": "Per-scrape limit on length of labels name that will be accepted for a sample. \n It requires Prometheus >= v2.27.0.",
+          "format": "int64",
+          "type": "integer"
+        },
+        "labelValueLengthLimit": {
+          "description": "Per-scrape limit on length of labels value that will be accepted for a sample. \n It requires Prometheus >= v2.27.0.",
+          "format": "int64",
+          "type": "integer"
+        },
+        "namespaceSelector": {
+          "description": "Selector to select which namespaces the Kubernetes `Endpoints` objects are discovered from.",
+          "properties": {
+            "any": {
+              "description": "Boolean describing whether all namespaces are selected in contrast to a list restricting them.",
+              "type": "boolean"
+            },
+            "matchNames": {
+              "description": "List of namespace names to select from.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "podTargetLabels": {
+          "description": "`podTargetLabels` defines the labels which are transferred from the associated Kubernetes `Pod` object onto the ingested metrics.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "sampleLimit": {
+          "description": "`sampleLimit` defines a per-scrape limit on the number of scraped samples that will be accepted.",
+          "format": "int64",
+          "type": "integer"
+        },
+        "selector": {
+          "description": "Label selector to select the Kubernetes `Endpoints` objects.",
+          "properties": {
+            "matchExpressions": {
+              "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+              "items": {
+                "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                "properties": {
+                  "key": {
+                    "description": "key is the label key that the selector applies to.",
+                    "type": "string"
+                  },
+                  "operator": {
+                    "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                    "type": "string"
+                  },
+                  "values": {
+                    "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  }
+                },
+                "required": [
+                  "key",
+                  "operator"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "matchLabels": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+              "type": "object"
+            }
+          },
+          "type": "object",
+          "x-kubernetes-map-type": "atomic",
+          "additionalProperties": false
+        },
+        "targetLabels": {
+          "description": "`targetLabels` defines the labels which are transferred from the associated Kubernetes `Service` object onto the ingested metrics.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "targetLimit": {
+          "description": "`targetLimit` defines a limit on the number of scraped targets that will be accepted.",
+          "format": "int64",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "selector"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "required": [
+    "spec"
+  ],
+  "type": "object"
+}

--- a/hacks/servicemonitor_v1.json
+++ b/hacks/servicemonitor_v1.json
@@ -50,9 +50,7 @@
                         "type": "boolean"
                       }
                     },
-                    "required": [
-                      "key"
-                    ],
+                    "required": ["key"],
                     "type": "object",
                     "x-kubernetes-map-type": "atomic",
                     "additionalProperties": false
@@ -84,9 +82,7 @@
                         "type": "boolean"
                       }
                     },
-                    "required": [
-                      "key"
-                    ],
+                    "required": ["key"],
                     "type": "object",
                     "x-kubernetes-map-type": "atomic",
                     "additionalProperties": false
@@ -107,9 +103,7 @@
                         "type": "boolean"
                       }
                     },
-                    "required": [
-                      "key"
-                    ],
+                    "required": ["key"],
                     "type": "object",
                     "x-kubernetes-map-type": "atomic",
                     "additionalProperties": false
@@ -138,9 +132,7 @@
                     "type": "boolean"
                   }
                 },
-                "required": [
-                  "key"
-                ],
+                "required": ["key"],
                 "type": "object",
                 "x-kubernetes-map-type": "atomic",
                 "additionalProperties": false
@@ -262,9 +254,7 @@
                             "type": "boolean"
                           }
                         },
-                        "required": [
-                          "key"
-                        ],
+                        "required": ["key"],
                         "type": "object",
                         "x-kubernetes-map-type": "atomic",
                         "additionalProperties": false
@@ -285,9 +275,7 @@
                             "type": "boolean"
                           }
                         },
-                        "required": [
-                          "key"
-                        ],
+                        "required": ["key"],
                         "type": "object",
                         "x-kubernetes-map-type": "atomic",
                         "additionalProperties": false
@@ -312,9 +300,7 @@
                         "type": "boolean"
                       }
                     },
-                    "required": [
-                      "key"
-                    ],
+                    "required": ["key"],
                     "type": "object",
                     "x-kubernetes-map-type": "atomic",
                     "additionalProperties": false
@@ -339,11 +325,7 @@
                     "type": "string"
                   }
                 },
-                "required": [
-                  "clientId",
-                  "clientSecret",
-                  "tokenUrl"
-                ],
+                "required": ["clientId", "clientSecret", "tokenUrl"],
                 "type": "object",
                 "additionalProperties": false
               },
@@ -441,10 +423,7 @@
               },
               "scheme": {
                 "description": "HTTP scheme to use for scraping. \n `http` and `https` are the expected values unless you rewrite the `__scheme__` label via relabeling. \n If empty, Prometheus uses the default value `http`.",
-                "enum": [
-                  "http",
-                  "https"
-                ],
+                "enum": ["http", "https"],
                 "type": "string"
               },
               "scrapeTimeout": {
@@ -486,9 +465,7 @@
                             "type": "boolean"
                           }
                         },
-                        "required": [
-                          "key"
-                        ],
+                        "required": ["key"],
                         "type": "object",
                         "x-kubernetes-map-type": "atomic",
                         "additionalProperties": false
@@ -509,9 +486,7 @@
                             "type": "boolean"
                           }
                         },
-                        "required": [
-                          "key"
-                        ],
+                        "required": ["key"],
                         "type": "object",
                         "x-kubernetes-map-type": "atomic",
                         "additionalProperties": false
@@ -543,9 +518,7 @@
                             "type": "boolean"
                           }
                         },
-                        "required": [
-                          "key"
-                        ],
+                        "required": ["key"],
                         "type": "object",
                         "x-kubernetes-map-type": "atomic",
                         "additionalProperties": false
@@ -566,9 +539,7 @@
                             "type": "boolean"
                           }
                         },
-                        "required": [
-                          "key"
-                        ],
+                        "required": ["key"],
                         "type": "object",
                         "x-kubernetes-map-type": "atomic",
                         "additionalProperties": false
@@ -605,9 +576,7 @@
                         "type": "boolean"
                       }
                     },
-                    "required": [
-                      "key"
-                    ],
+                    "required": ["key"],
                     "type": "object",
                     "x-kubernetes-map-type": "atomic",
                     "additionalProperties": false
@@ -708,10 +677,7 @@
                     "type": "array"
                   }
                 },
-                "required": [
-                  "key",
-                  "operator"
-                ],
+                "required": ["key", "operator"],
                 "type": "object",
                 "additionalProperties": false
               },
@@ -742,15 +708,11 @@
           "type": "integer"
         }
       },
-      "required": [
-        "selector"
-      ],
+      "required": ["selector"],
       "type": "object",
       "additionalProperties": false
     }
   },
-  "required": [
-    "spec"
-  ],
+  "required": ["spec"],
   "type": "object"
 }

--- a/hacks/values/hydra.yaml
+++ b/hacks/values/hydra.yaml
@@ -129,6 +129,7 @@ watcher:
     runAsNonRoot: true
 
 serviceMonitor:
+  enabled: true
   labels:
     release: "prometheus"
   tlsConfig:

--- a/hacks/values/kratos.yaml
+++ b/hacks/values/kratos.yaml
@@ -322,6 +322,7 @@ cronjob:
       runAsNonRoot: true
 
 serviceMonitor:
+  enabled: true
   labels:
     release: "prometheus"
   tlsConfig:

--- a/helm/charts/hydra/templates/service-admin.yaml
+++ b/helm/charts/hydra/templates/service-admin.yaml
@@ -32,7 +32,7 @@ spec:
   selector:
     app.kubernetes.io/name: {{ include "hydra.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
-{{- if and (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1") (.Values.serviceMonitor.enabled) }}
+{{- if .Values.serviceMonitor.enabled }}
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor

--- a/helm/charts/hydra/values.yaml
+++ b/helm/charts/hydra/values.yaml
@@ -606,8 +606,8 @@ pdb:
 # -- Parameters for the Prometheus ServiceMonitor objects.
 # Reference: https://docs.openshift.com/container-platform/4.6/rest_api/monitoring_apis/servicemonitor-monitoring-coreos-com-v1.html
 serviceMonitor:
-  # -- switch to false to prevent creating the ServiceMonitor
-  enabled: true
+  # -- switch to true to enable creating the ServiceMonitor
+  enabled: false
   # -- HTTP scheme to use for scraping.
   scheme: http
   # -- Interval at which metrics should be scraped

--- a/helm/charts/kratos/templates/service-admin.yaml
+++ b/helm/charts/kratos/templates/service-admin.yaml
@@ -32,7 +32,7 @@ spec:
   selector:
     app.kubernetes.io/name: {{ include "kratos.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
-{{- if and (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1") (.Values.serviceMonitor.enabled) }}
+{{- if .Values.serviceMonitor.enabled }}
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor

--- a/helm/charts/kratos/values.yaml
+++ b/helm/charts/kratos/values.yaml
@@ -688,8 +688,8 @@ pdb:
 # -- Parameters for the Prometheus ServiceMonitor objects.
 # Reference: https://docs.openshift.com/container-platform/4.6/rest_api/monitoring_apis/servicemonitor-monitoring-coreos-com-v1.html
 serviceMonitor:
-  # -- switch to false to prevent creating the ServiceMonitor
-  enabled: true
+  # -- switch to true to enable creating the ServiceMonitor
+  enabled: false
   # -- HTTP scheme to use for scraping.
   scheme: http
   # -- Interval at which metrics should be scraped


### PR DESCRIPTION
Remove the `.Capabilities.APIVersions.Has "monitoring.coreos.com/v1"` check done before enabling the service monitor
as this test will always fail

To avoid breaking changes, the default value for `.Values.serviceMonitor.enabled` is set to false.

## Related Issue or Design Document

<!--
If this pull request

1. is a fix for a known bug, link the issue where the bug was reported in the format of `#1234`;
2. is a fix for a previously unknown bug, explain the bug and how to reproduce it in this pull request;
3. implements a new feature, link the issue containing the design document in the format of `#1234`;
4. improves the documentation, no issue reference is required.

Pull requests introducing new features, which do not have a design document linked are more likely to be rejected and take on average 2-8 weeks longer to
get merged.

You can discuss changes with maintainers either in the Github Discussions in this repository or
join the [Ory Chat](https://www.ory.sh/chat).
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [ x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md) and signed the CLA.
- [ x] I have referenced an issue containing the design document if my change introduces a new feature.
- [ x] I have read the [security policy](../security/policy).
- [ x] I confirm that this pull request does not address a security vulnerability. 
      If this pull request addresses a security vulnerability, 
      I confirm that I got approval (please contact [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push the changes.
- [ x] I have added tests that prove my fix is effective or that my feature works.
- [ x] I have added the necessary documentation within the code base (if appropriate).

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
