### PR TITLE
fix: add support for using nodeport in kratos and kratos-selfservice-ui-no…

### DIFF
--- a/helm/charts/kratos-selfservice-ui-node/templates/service.yaml
+++ b/helm/charts/kratos-selfservice-ui-node/templates/service.yaml
@@ -16,6 +16,11 @@ spec:
       targetPort: http
       protocol: TCP
       name: {{ .Values.service.name }}
+      {{- if eq .Values.service.type "NodePort" }}
+      {{- with .Values.service.nodePort }}
+      nodePort: {{ . }}
+      {{- end }}
+      {{- end }}
   selector:
     app.kubernetes.io/name: {{ include "kratos-selfservice-ui-node.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}

--- a/helm/charts/kratos-selfservice-ui-node/values.yaml
+++ b/helm/charts/kratos-selfservice-ui-node/values.yaml
@@ -28,6 +28,7 @@ service:
   type: ClusterIP
   # -- The load balancer IP
   loadBalancerIP: ""
+  nodePort: ""
   port: 80
   # -- The service port name. Useful to set a custom service port name if it must follow a scheme (e.g. Istio)
   name: http

--- a/helm/charts/kratos/templates/service-admin.yaml
+++ b/helm/charts/kratos/templates/service-admin.yaml
@@ -29,6 +29,11 @@ spec:
       targetPort: http-admin
       protocol: TCP
       name: {{ .Values.service.admin.name }}
+      {{- if eq .Values.service.admin.type "NodePort" }}
+      {{- with .Values.service.admin.nodePort }}
+      nodePort: {{ . }}
+      {{- end }}
+      {{- end }}
   selector:
     app.kubernetes.io/name: {{ include "kratos.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}

--- a/helm/charts/kratos/templates/service-public.yaml
+++ b/helm/charts/kratos/templates/service-public.yaml
@@ -28,6 +28,11 @@ spec:
       targetPort: http-public
       protocol: TCP
       name: {{ .Values.service.public.name }}
+      {{- if eq .Values.service.public.type "NodePort" }}
+      {{- with .Values.service.public.nodePort }}
+      nodePort: {{ . }}
+      {{- end }}
+      {{- end }}
   selector:
     app.kubernetes.io/name: {{ include "kratos.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}

--- a/helm/charts/kratos/values.yaml
+++ b/helm/charts/kratos/values.yaml
@@ -30,6 +30,7 @@ service:
     type: ClusterIP
     # -- Load balancer IP
     loadBalancerIP: ""
+    nodePort: ""
     port: 80
     # -- The service port name. Useful to set a custom service port name if it must follow a scheme (e.g. Istio)
     name: http
@@ -47,6 +48,7 @@ service:
     type: ClusterIP
     # -- Load balancer IP
     loadBalancerIP: ""
+    nodePort: ""
     port: 80
     # -- The service port name. Useful to set a custom service port name if it must follow a scheme (e.g. Istio)
     name: http


### PR DESCRIPTION
Resolves https://github.com/ory/k8s/issues/661

This PR enables use of NodePort service while deploying kratos and kratos-selfservice-ui-node helm charts.

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md) and signed the CLA.
- [x] I have referenced an issue containing the design document if my change introduces a new feature.
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security vulnerability. 