### PR TITLE
fix: ensure oathkeeper controller deployment correctly account for optionally created resources.

### DIFF
--- a/helm/charts/oathkeeper/templates/deployment-controller.yaml
+++ b/helm/charts/oathkeeper/templates/deployment-controller.yaml
@@ -62,14 +62,38 @@ spec:
             name: {{ include "oathkeeper.fullname" . }}-config
             {{- end }}
         - name: {{ include "oathkeeper.name" . }}-rules-volume
+          {{- if .Values.oathkeeper.managedAccessRules }}
           configMap:
             name: {{ include "oathkeeper.fullname" . }}-rules
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
+        {{- if .Values.secret.enabled }}
         - name: {{ include "oathkeeper.name" . }}-secrets-volume
           secret:
             secretName: {{ include "oathkeeper.secretname" . }}
+        {{- end }}
       serviceAccountName: {{ include "oathkeeper.serviceAccountName" . }}
       automountServiceAccountToken: {{ .Values.deployment.automountServiceAccountToken }}
       initContainers:
+      {{- if (not .Values.oathkeeper.managedAccessRules) }}
+        - name: init
+          image: "{{ .Values.image.initContainer.repository }}:{{ .Values.image.initContainer.tag }}"
+          volumeMounts:
+            - name: {{ include "oathkeeper.name" . }}-rules-volume
+              mountPath: /etc/rules
+              readOnly: false
+          command:
+            - sh
+            - -c
+            - |
+              touch /etc/rules/access-rules.json
+              chmod 666 /etc/rules/access-rules.json
+          {{- if .Values.securityContext }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          {{- end }}
+      {{- end }}
       {{- if .Values.deployment.extraInitContainers }}
         {{- tpl  .Values.deployment.extraInitContainers . | nindent 8 }}
       {{- end }}
@@ -88,7 +112,7 @@ spec:
               {{- toYaml . | nindent 12 }}
             {{- end }}
           env:
-            {{- if .Values.oathkeeper.mutatorIdTokenJWKs }}
+            {{- if and .Values.secret.enabled .Values.oathkeeper.mutatorIdTokenJWKs }}
             - name: MUTATORS_ID_TOKEN_CONFIG_JWKS_URL
               value: "file://{{ .Values.secret.mountPath }}/{{ .Values.secret.filename }}"
             {{- end }}
@@ -105,9 +129,11 @@ spec:
             - name: {{ include "oathkeeper.name" . }}-rules-volume
               mountPath: /etc/rules
               readOnly: true
+            {{- if .Values.secret.enabled }}
             - name: {{ include "oathkeeper.name" . }}-secrets-volume
               mountPath: {{ .Values.secret.mountPath }}
               readOnly: true
+            {{- end }}
           ports:
             - name: http-api
               containerPort: {{ .Values.oathkeeper.config.serve.api.port }}


### PR DESCRIPTION
This fix ensures that the oathkeeper controller deployment template correctly accounts for optional creation of configmap and secrets based on the provided values:
- `oathkeeper.secret.enabled`
- `secret.enabled`

## Related Issue or Design Document
n/a (couldn't find an open/closed issue for the controller failing to initialize due to configmap missing for rules)

## Checklist
- [X] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md) and signed the CLA.
- [X] I have referenced an issue containing the design document if my change introduces a new feature.
- [X] I have read the [security policy](../security/policy).
- [X] I confirm that this pull request does not address a security vulnerability. 
      If this pull request addresses a security vulnerability, 
      I confirm that I got approval (please contact [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push the changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [X] I have added the necessary documentation within the code base (if appropriate).

## Further comments
this pr assumed that it should be possible to deploy the maester as a controller whilst also allowing it to manage the access rules. if this is incorrect, im happy to adjust the logic to ensure that the configmap for access rules get created unles *both* `managedAccessRules` is `false` and the maester mode is `sidecar`.

also please let me know if i need to increment the chart's semver patch for fixes; wasn't clear in the checklist above.