### PR TITLE
Allow self managed rules without maester disabled in PR #669

### DIFF
--- a/helm/charts/oathkeeper/templates/deployment-controller.yaml
+++ b/helm/charts/oathkeeper/templates/deployment-controller.yaml
@@ -62,7 +62,7 @@ spec:
             name: {{ include "oathkeeper.fullname" . }}-config
             {{- end }}
         - name: {{ include "oathkeeper.name" . }}-rules-volume
-          {{- if .Values.oathkeeper.managedAccessRules }}
+          {{- if or .Values.oathkeeper.managedAccessRules ( not .Values.maester.enabled ) }}
           configMap:
             name: {{ include "oathkeeper.fullname" . }}-rules
           {{- else }}
@@ -76,7 +76,7 @@ spec:
       serviceAccountName: {{ include "oathkeeper.serviceAccountName" . }}
       automountServiceAccountToken: {{ .Values.deployment.automountServiceAccountToken }}
       initContainers:
-      {{- if (not .Values.oathkeeper.managedAccessRules) }}
+      {{- if ( not ( or .Values.oathkeeper.managedAccessRules ( not .Values.maester.enabled ) ) ) }}
         - name: init
           image: "{{ .Values.image.initContainer.repository }}:{{ .Values.image.initContainer.tag }}"
           volumeMounts:


### PR DESCRIPTION
Since PR #669, self-managed access rules are impossible to deploy. This commit fixes that by allowing the deployment controller to load the rules config map when maester is disabled.

## Related Issue or Design Document

In PR #669, logic was added to the deployment controller such that the access rules configmap would not be loaded when `.Values.managedAccessRules` was false. This breaks down self-templated access rules when maester is not desired.

## Checklist

- [X] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md) and signed the CLA.
- [X] I have referenced an issue containing the design document if my change introduces a new feature.
- [X] I have read the [security policy](../security/policy).
- [X] I confirm that this pull request does not address a security vulnerability. 
      If this pull request addresses a security vulnerability, 
      I confirm that I got approval (please contact [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push the changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [X] I have added the necessary documentation within the code base (if appropriate).

## Further comments

There might be other ways to address this. Let me know if you have other suggestions. In PR #669, a suggestion was made restrict the logic only when maester's sideloader mode was enabled @cbrendanprice . This might be a solution as well.
