### PR TITLE
fix: disable maester by default

### DIFF
--- a/hacks/values/oathkeeper.yaml
+++ b/hacks/values/oathkeeper.yaml
@@ -68,6 +68,7 @@ deployment:
       maxSurge: 25%
       maxUnavailable: 25%
 oathkeeper:
+  managedAccessRules: true
   accessRules: |
     [
       {

--- a/helm/charts/oathkeeper/templates/_helpers.tpl
+++ b/helm/charts/oathkeeper/templates/_helpers.tpl
@@ -24,6 +24,21 @@ If release name contains chart name it will be used as a full name.
 {{- end -}}
 {{- end -}}
 
+
+{{/*
+Create a config map name for rules.
+If maester is enabled, use the child chart named template to get the value.
+*/}}
+{{- define "oathkeeper.rulesConfigMapName" -}}
+{{- if .Values.maester.enabled -}}
+{{- $childChart := (dict "Name" "oathkeeper-maester") -}}
+{{- include "oathkeeper-maester.getCM" (dict "Values" (index .Values "oathkeeper-maester") "Release" $.Release "Chart" $childChart) }}
+{{- else -}}
+{{ include "oathkeeper.fullname" . }}-rules
+{{- end -}}
+{{- end -}}
+
+
 {{/*
 Create a secret name which can be overridden.
 */}}
@@ -86,7 +101,9 @@ Checksum annotations generated from configmaps and secrets
 {{- if .Values.configmap.hashSumEnabled }}
 {{- $oathkeeperConfigMapFile := ternary "/configmap-config-demo.yaml" "/configmap-config.yaml" (.Values.demo) }}
 checksum/oathkeeper-config: {{ include (print $.Template.BasePath $oathkeeperConfigMapFile) . | sha256sum }}
+{{- if .Values.oathkeeper.managedAccessRules }}
 checksum/oathkeeper-rules: {{ include (print $.Template.BasePath "/configmap-rules.yaml") . | sha256sum }}
+{{- end }}
 {{- end }}
 {{- if and .Values.secret.enabled .Values.secret.hashSumEnabled }}
 checksum/oauthkeeper-secrets: {{ include (print $.Template.BasePath "/secrets.yaml") . | sha256sum }}

--- a/helm/charts/oathkeeper/templates/configmap-rules.yaml
+++ b/helm/charts/oathkeeper/templates/configmap-rules.yaml
@@ -1,4 +1,7 @@
 {{- if .Values.oathkeeper.managedAccessRules }}
+{{- if .Values.maester.enabled -}}
+{{- fail "Both `managedAccessRules` and `maester.enabled` cannot be set to true at the same time" }}
+{{- end -}}
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/helm/charts/oathkeeper/templates/deployment-controller.yaml
+++ b/helm/charts/oathkeeper/templates/deployment-controller.yaml
@@ -62,9 +62,9 @@ spec:
             name: {{ include "oathkeeper.fullname" . }}-config
             {{- end }}
         - name: {{ include "oathkeeper.name" . }}-rules-volume
-          {{- if .Values.oathkeeper.managedAccessRules }}
+          {{- if or .Values.oathkeeper.managedAccessRules .Values.maester.enabled }}
           configMap:
-            name: {{ include "oathkeeper.fullname" . }}-rules
+            name: {{ include "oathkeeper.rulesConfigMapName" . }}
           {{- else }}
           emptyDir: {}
           {{- end }}
@@ -76,7 +76,7 @@ spec:
       serviceAccountName: {{ include "oathkeeper.serviceAccountName" . }}
       automountServiceAccountToken: {{ .Values.deployment.automountServiceAccountToken }}
       initContainers:
-      {{- if (not .Values.oathkeeper.managedAccessRules) }}
+      {{- if and (not .Values.oathkeeper.managedAccessRules) (not .Values.maester.enabled) }}
         - name: init
           image: "{{ .Values.image.initContainer.repository }}:{{ .Values.image.initContainer.tag }}"
           volumeMounts:

--- a/helm/charts/oathkeeper/values.yaml
+++ b/helm/charts/oathkeeper/values.yaml
@@ -378,7 +378,7 @@ affinity: {}
 
 ## -- Configures controller setup
 maester:
-  enabled: true
+  enabled: false
 
 ## -- PodDistributionBudget configuration
 pdb:


### PR DESCRIPTION
This patch changes the default value `maester.enabled` to `false`. If the user would like to manage the rules with the maester controller, `maester.enabled` should be set to `true` and `managedAccessRules` should be set to `false`

## Related Issue or Design Document
Fixes #512
## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md) and signed the CLA.
- [x] I have referenced an issue containing the design document if my change introduces a new feature.
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security vulnerability. 
      If this pull request addresses a security vulnerability, 
      I confirm that I got approval (please contact [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push the changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added the necessary documentation within the code base (if appropriate).

## Further comments

Tested with the following configurations:

1- The user would like to manage rules manually. In this configuration the rules configmap and the initContainer to fix the permissions are not added to the deployment. rules volume is an emptydir:
```
oathkeeper:
  managedAccessRules: false
maester:
  enabled: false
```

2- The rules are managed by the helm chart `oathkeeper.accessRules` value. Rules configmap is created but the initContainer is not added to the deployment.
```
oathkeeper:
  managedAccessRules: true
maester:
  enabled: false
```

3- The rules are managed by the maester. Rules configmap is created by the maester chart and the volume name in the oathkeeper deployment is aligned with the maester chart. initContainer is not added to the deployment.
```
oathkeeper:
  managedAccessRules: false
maester:
  enabled: true
```

4- Invalid configuration so the helm chart rendering fails with an error message.
```
oathkeeper:
  managedAccessRules: true
maester:
  enabled: true
```

I believe the first configuration (where the chart creates an emptydir volume) should be replaced with a configuration where the chart gets an existing configmap name and uses that instead. 