### PR TITLE
feat: support enable, labels, and annotations for selfservice-ui service

### DIFF
--- a/helm/charts/kratos-selfservice-ui-node/README.md
+++ b/helm/charts/kratos-selfservice-ui-node/README.md
@@ -63,6 +63,9 @@ A Helm chart for ORY Kratos's example ui for Kubernetes
 | securityContext.runAsUser | int | `10000` |  |
 | securityContext.seLinuxOptions.level | string | `"s0:c123,c456"` |  |
 | securityContext.seccompProfile.type | string | `"RuntimeDefault"` |  |
+| service.annotations | object | `{}` | If you do want to specify annotations, uncomment the following lines, adjust them as necessary, and remove the curly braces after 'annotations:'. |
+| service.enabled | bool | `true` | En-/disable the service |
+| service.labels | object | `{}` | Provide custom labels. Use the same syntax as for annotations. |
 | service.loadBalancerIP | string | `""` | The load balancer IP |
 | service.name | string | `"http"` | The service port name. Useful to set a custom service port name if it must follow a scheme (e.g. Istio) |
 | service.nodePort | string | `""` |  |

--- a/helm/charts/kratos-selfservice-ui-node/templates/service.yaml
+++ b/helm/charts/kratos-selfservice-ui-node/templates/service.yaml
@@ -1,9 +1,18 @@
+{{- if .Values.service.enabled -}}
+---
 apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "kratos-selfservice-ui-node.fullname" . }}
   labels:
-{{ include "kratos-selfservice-ui-node.labels" . | indent 4 }}
+    {{- include "kratos-selfservice-ui-node.labels" . | nindent 4 }}
+    {{- with .Values.service.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+  annotations:
+    {{- with .Values.service.annotations }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   type: {{ .Values.service.type }}
   {{- if eq .Values.service.type "LoadBalancer" }}
@@ -24,3 +33,4 @@ spec:
   selector:
     app.kubernetes.io/name: {{ include "kratos-selfservice-ui-node.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/helm/charts/kratos-selfservice-ui-node/values.yaml
+++ b/helm/charts/kratos-selfservice-ui-node/values.yaml
@@ -25,6 +25,7 @@ config:
 
 ## -- Service configuration
 service:
+  enabled: true
   type: ClusterIP
   # -- The load balancer IP
   loadBalancerIP: ""
@@ -32,6 +33,13 @@ service:
   port: 80
   # -- The service port name. Useful to set a custom service port name if it must follow a scheme (e.g. Istio)
   name: http
+  # -- Provide custom labels. Use the same syntax as for annotations.
+  labels: {}
+  # -- If you do want to specify annotations, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'annotations:'.
+  annotations: {}
+  # kubernetes.io/ingress.class: nginx
+  # kubernetes.io/tls-acme: "true"
 
 ## -- Secret configuration
 secret:


### PR DESCRIPTION
Add support for `enabled`, `labels`, and `annotations` to the `kratos-selfservice-ui-node` Kubernetes Service.

## Related Issue or Design Document

N/A

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md) and signed the CLA.
- [ ] I have referenced an issue containing the design document if my change introduces a new feature.
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security vulnerability. 
      If this pull request addresses a security vulnerability, 
      I confirm that I got approval (please contact [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push the changes.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added the necessary documentation within the code base (if appropriate).

## Further comments

This brings the features of this chart in line with other Ory Helm charts.

Local validation performed with:

```sh
helm template kratos-ui . -s templates/service.yaml
helm template kratos-ui . -s templates/service.yaml --set 'service.enabled=false'
helm template kratos-ui . -s templates/service.yaml --set 'service.labels.foo=bar'
helm template kratos-ui . -s templates/service.yaml --set 'service.annotations.foo=bar'
```
