### PR TITLE
feat: template configmaps

### DIFF
--- a/hacks/values/hydra.yaml
+++ b/hacks/values/hydra.yaml
@@ -26,6 +26,8 @@ hydra:
         - "foo bar 123 456 lorem 1"
         - "foo bar 123 456 lorem 2"
         - "foo bar 123 456 lorem 3"
+    log:
+      redaction_text: "example template {{ .Release.Name }}"
 
 secret:
   enabled: false

--- a/hacks/values/keto.yaml
+++ b/hacks/values/keto.yaml
@@ -6,6 +6,8 @@ keto:
       - keto
   config:
     dsn: "postgres://postgres:ory@postgresql.default.svc.cluster.local/ory_keto?sslmode=disable&max_conn_lifetime=10s"
+    log:
+      redaction_text: "example template {{ .Release.Name }}"
 ingress:
   read:
     enabled: true

--- a/hacks/values/oathkeeper.yaml
+++ b/hacks/values/oathkeeper.yaml
@@ -130,6 +130,8 @@ oathkeeper:
     authenticators:
       noop:
         enabled: true
+    log:
+      redaction_text: "example template {{ .Release.Name }}"
 
 secret:
   enabled: true

--- a/helm/charts/hydra/templates/_helpers.tpl
+++ b/helm/charts/hydra/templates/_helpers.tpl
@@ -125,7 +125,7 @@ Generate the configmap data, redacting secrets
 */}}
 {{- define "hydra.configmap" -}}
 {{- $config := omit .Values.hydra.config "dsn" "secrets" -}}
-{{- toYaml $config -}}
+{{- tpl (toYaml $config) . -}}
 {{- end -}}
 
 {{/*

--- a/helm/charts/keto/templates/_helpers.tpl
+++ b/helm/charts/keto/templates/_helpers.tpl
@@ -57,7 +57,7 @@ Generate the configmap data, redacting secrets
 */}}
 {{- define "keto.configmap" -}}
 {{- $config := omit .Values.keto.config "dsn" -}}
-{{- toYaml $config -}}
+{{- tpl (toYaml $config) . -}}
 {{- end -}}
 
 {{/*

--- a/helm/charts/oathkeeper/templates/_helpers.tpl
+++ b/helm/charts/oathkeeper/templates/_helpers.tpl
@@ -26,6 +26,14 @@ If release name contains chart name it will be used as a full name.
 
 
 {{/*
+Generate the configmap data, redacting secrets
+*/}}
+{{- define "oathkeeper.configmap" -}}
+{{- $config := .Values.oathkeeper.config -}}
+{{- tpl (toYaml $config) . -}}
+{{- end -}}
+
+{{/*
 Create a config map name for rules.
 If maester is enabled, use the child chart named template to get the value.
 */}}

--- a/helm/charts/oathkeeper/templates/configmap-config.yaml
+++ b/helm/charts/oathkeeper/templates/configmap-config.yaml
@@ -11,7 +11,5 @@ metadata:
 {{ include "oathkeeper.labels" . | indent 4 }}
 data:
   "config.yaml": |
-{{- with .Values.oathkeeper.config -}}  
-  {{- toYaml . | nindent 4 }} 
-{{- end -}}
+    {{- include "oathkeeper.configmap" . | nindent 4 }}
 {{ end }}


### PR DESCRIPTION
The Kratos chart allows templating the config settings in the chart values via the Helm `tpl` function, but the other charts don't allow this. Templating is very helpful for if you need to provide values which are based on other values in your environment, e.g. if parts of URLs include the `{{ .Release.Name }}` as they do with many 3rd party charts.

This PR includes:
- Keto: add `tpl` to the existing `keto.configmap` helper
- Hydra: add `tpl` to the existing `hydra.configmap` helper
- Oathkeeper: add a `oathkeeper.configmap` helper which behaves the same as the other charts

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md) and signed the CLA.
- [ ] I have referenced an issue containing the design document if my change introduces a new feature.
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security vulnerability. 
      If this pull request addresses a security vulnerability, 
      I confirm that I got approval (please contact [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push the changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added the necessary documentation within the code base (if appropriate).