### PR TITLE
feat: template extraEnv

### DIFF
--- a/hacks/values/hydra.yaml
+++ b/hacks/values/hydra.yaml
@@ -80,6 +80,8 @@ deployment:
   extraEnv:
     - name: FOO
       value: BAR
+    - name: RELEASE_NAME
+      value: "{{ .Release.Name }}"
   extraVolumeMounts:
     - mountPath: /testdir
       name: test-volume

--- a/hacks/values/keto.yaml
+++ b/hacks/values/keto.yaml
@@ -52,6 +52,8 @@ deployment:
   extraEnv:
     - name: FOO
       value: BAR
+    - name: RELEASE_NAME
+      value: "{{ .Release.Name }}"
   extraVolumeMounts:
     - mountPath: /testdir
       name: test-volume

--- a/hacks/values/kratos.yaml
+++ b/hacks/values/kratos.yaml
@@ -234,6 +234,8 @@ deployment:
         secretKeyRef:
           name: dsn-secret
           key: dsn
+    - name: RELEASE_NAME
+      value: "{{ .Release.Name }}"
   customLivenessProbe:
     failureThreshold: 5
     exec:

--- a/hacks/values/oathkeeper.yaml
+++ b/hacks/values/oathkeeper.yaml
@@ -46,6 +46,9 @@ deployment:
       image: "alpine:latest"
       command: ["/bin/sh"]
       args: ["-c", "sleep infinity"]
+  extraEnv:
+    - name: RELEASE_NAME
+      value: "{{ .Release.Name }}"
   podMetadata:
     labels:
       ory.sh/pod_label: oathkeeper

--- a/helm/charts/hydra/README.md
+++ b/helm/charts/hydra/README.md
@@ -36,7 +36,7 @@ A Helm chart for deploying ORY Hydra in Kubernetes
 | cronjob.janitor.customArgs | list | `[]` | Configure the arguments of the entrypoint, overriding the default value |
 | cronjob.janitor.customCommand | list | `[]` | Configure a custom entrypoint, overriding the default value |
 | cronjob.janitor.extraContainers | string | `""` | If you want to add extra sidecar containers. |
-| cronjob.janitor.extraEnv | list | `[]` | Array of extra envs to be passed to the cronjob. This takes precedence over deployment variables. Kubernetes format is expected - name: FOO   value: BAR |
+| cronjob.janitor.extraEnv | list | `[]` | Array of extra envs to be passed to the cronjob. This takes precedence over deployment variables. Kubernetes format is expected. Value is processed with Helm `tpl` - name: FOO   value: BAR |
 | cronjob.janitor.extraInitContainers | string | `""` | If you want to add extra init containers. These are processed before the migration init container. |
 | cronjob.janitor.extraVolumeMounts | list | `[]` |  |
 | cronjob.janitor.extraVolumes | list | `[]` | If you want to mount external volume |
@@ -56,7 +56,7 @@ A Helm chart for deploying ORY Hydra in Kubernetes
 | cronjob.janitor.tolerations | list | `[]` | Configure node tolerations |
 | deployment.annotations | object | `{}` | Set custom deployment level annotations |
 | deployment.automigration | object | `{"extraEnv":[]}` | Parameters for the automigration initContainer |
-| deployment.automigration.extraEnv | list | `[]` | Array of extra envs to be passed to the initContainer. Kubernetes format is expected - name: FOO   value: BAR |
+| deployment.automigration.extraEnv | list | `[]` | Array of extra envs to be passed to the initContainer. Kubernetes format is expected. Value is processed with Helm `tpl` - name: FOO   value: BAR |
 | deployment.automountServiceAccountToken | bool | `false` |  |
 | deployment.autoscaling | object | `{"behavior":{},"enabled":false,"maxReplicas":3,"minReplicas":1,"targetCPU":{},"targetMemory":{}}` | Configure HPA |
 | deployment.autoscaling.behavior | object | `{}` | Set custom behavior https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#configurable-scaling-behavior |
@@ -65,7 +65,7 @@ A Helm chart for deploying ORY Hydra in Kubernetes
 | deployment.customStartupProbe | object | `{}` | Configure a custom startupProbe. This overwrites the default object |
 | deployment.dnsConfig | object | `{}` | Configure pod dnsConfig. |
 | deployment.extraContainers | string | `""` | If you want to add extra sidecar containers. |
-| deployment.extraEnv | list | `[]` | Array of extra envs to be passed to the deployment. Kubernetes format is expected - name: FOO   value: BAR |
+| deployment.extraEnv | list | `[]` | Array of extra envs to be passed to the deployment. Kubernetes format is expected. Value is processed with Helm `tpl` - name: FOO   value: BAR |
 | deployment.extraInitContainers | string | `""` | If you want to add extra init containers. These are processed before the migration init container. |
 | deployment.extraVolumeMounts | list | `[]` |  |
 | deployment.extraVolumes | list | `[]` | If you want to mount external volume |
@@ -139,7 +139,7 @@ A Helm chart for deploying ORY Hydra in Kubernetes
 | job.annotations | object | `{"helm.sh/hook":"pre-install, pre-upgrade","helm.sh/hook-delete-policy":"before-hook-creation","helm.sh/hook-weight":"1"}` | If you do want to specify annotations, uncomment the following lines, adjust them as necessary, and remove the curly braces after 'annotations:'. |
 | job.automountServiceAccountToken | bool | `true` | Set automounting of the SA token |
 | job.extraContainers | string | `""` | If you want to add extra sidecar containers. |
-| job.extraEnv | list | `[]` | Array of extra envs to be passed to the job. This takes precedence over deployment variables. Kubernetes format is expected - name: FOO   value: BAR |
+| job.extraEnv | list | `[]` | Array of extra envs to be passed to the job. This takes precedence over deployment variables. Kubernetes format is expected. Value is processed with Helm `tpl` - name: FOO   value: BAR |
 | job.extraInitContainers | string | `""` | If you want to add extra init containers. extraInitContainers: |  - name: ...    image: ... |
 | job.labels | object | `{}` | Set custom deployment level labels |
 | job.lifecycle | string | `""` | If you want to add lifecycle hooks. |

--- a/helm/charts/hydra/templates/deployment.yaml
+++ b/helm/charts/hydra/templates/deployment.yaml
@@ -154,8 +154,8 @@ spec:
                 secretKeyRef:
                   name: {{ include "hydra.secretname" . }}
                   key: secretsCookie
-            {{- with .Values.deployment.extraEnv }}
-              {{- toYaml . | nindent 12 }}
+            {{- if .Values.deployment.extraEnv }}
+              {{- tpl (toYaml .Values.deployment.extraEnv) . | nindent 12 }}
             {{- end }}
           resources:
             {{- toYaml .Values.deployment.resources | nindent 12 }}
@@ -203,8 +203,8 @@ spec:
                   key: dsn
               {{- end }}
             {{- end }}
-            {{- with $migrationExtraEnv }}
-              {{- toYaml . | nindent 12 }}
+            {{- if $migrationExtraEnv }}
+              {{- tpl (toYaml $migrationExtraEnv) . | nindent 12 }}
             {{- end }}
           {{- if .Values.hydra.automigration.resources }}
           resources:

--- a/helm/charts/hydra/values.yaml
+++ b/helm/charts/hydra/values.yaml
@@ -246,14 +246,16 @@ deployment:
   # lines, adjust them as necessary, and remove the curly braces after 'nodeSelector:'.
   #   foo: bar
 
-  # -- Array of extra envs to be passed to the deployment. Kubernetes format is expected
+  # -- Array of extra envs to be passed to the deployment. Kubernetes format is expected. Value is processed with Helm
+  # `tpl`
   # - name: FOO
   #   value: BAR
   extraEnv: []
 
   # -- Parameters for the automigration initContainer
   automigration:
-    # -- Array of extra envs to be passed to the initContainer. Kubernetes format is expected
+    # -- Array of extra envs to be passed to the initContainer. Kubernetes format is expected. Value is processed with
+    # Helm `tpl`
     # - name: FOO
     #   value: BAR
     extraEnv: []
@@ -391,7 +393,8 @@ job:
   #  - name: ...
   #    image: ...
 
-  # -- Array of extra envs to be passed to the job. This takes precedence over deployment variables. Kubernetes format is expected
+  # -- Array of extra envs to be passed to the job. This takes precedence over deployment variables. Kubernetes format
+  # is expected. Value is processed with Helm `tpl`
   # - name: FOO
   #   value: BAR
   extraEnv: []
@@ -534,7 +537,8 @@ cronjob:
     # -- Configure the arguments of the entrypoint, overriding the default value
     customArgs: []
 
-    # -- Array of extra envs to be passed to the cronjob. This takes precedence over deployment variables. Kubernetes format is expected
+    # -- Array of extra envs to be passed to the cronjob. This takes precedence over deployment variables. Kubernetes
+    # format is expected. Value is processed with Helm `tpl`
     # - name: FOO
     #   value: BAR
     extraEnv: []

--- a/helm/charts/keto/README.md
+++ b/helm/charts/keto/README.md
@@ -31,7 +31,7 @@ Access Control Policies as a Server
 | deployment.affinity | object | `{}` |  |
 | deployment.annotations | object | `{}` |  |
 | deployment.automigration | object | `{"extraEnv":[]}` | Parameters for the automigration initContainer |
-| deployment.automigration.extraEnv | list | `[]` | Array of extra envs to be passed to the initContainer. Kubernetes format is expected - name: FOO   value: BAR |
+| deployment.automigration.extraEnv | list | `[]` | Array of extra envs to be passed to the initContainer. Kubernetes format is expected. Value is processed with Helm `tpl` - name: FOO   value: BAR |
 | deployment.automountServiceAccountToken | bool | `true` |  |
 | deployment.autoscaling | object | `{"behavior":{},"enabled":false,"maxReplicas":100,"minReplicas":1,"targetCPU":{},"targetMemory":{}}` | Autoscaling for keto deployment |
 | deployment.autoscaling.behavior | object | `{}` | Set custom behavior https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#configurable-scaling-behavior |
@@ -40,7 +40,7 @@ Access Control Policies as a Server
 | deployment.customStartupProbe | object | `{}` |  |
 | deployment.dnsConfig | object | `{}` | Configure pod dnsConfig. |
 | deployment.extraContainers | string | `""` | If you want to add extra sidecar containers. |
-| deployment.extraEnv | list | `[]` | Array of extra Envs to be added to the deployment. K8s format expected - name: FOO   value: BAR |
+| deployment.extraEnv | list | `[]` | Array of extra Envs to be added to the deployment. Kubernetes format expected. Value is processed with Helm `tpl` - name: FOO   value: BAR |
 | deployment.extraInitContainers | object | `{}` | If you want to add extra init containers. These are processed before the migration init container. |
 | deployment.extraLabels | object | `{}` | Extra labels to be added to the deployment, and pods. K8s object format expected foo: bar my.special.label/type: value |
 | deployment.extraPorts | list | `[]` | Extra ports to be exposed by the main deployment |
@@ -94,7 +94,7 @@ Access Control Policies as a Server
 | job.annotations | object | `{"helm.sh/hook":"pre-install, pre-upgrade","helm.sh/hook-delete-policy":"before-hook-creation,hook-succeeded","helm.sh/hook-weight":"1"}` | If you do want to specify annotations, uncomment the following lines, adjust them as necessary, and remove the curly braces after 'annotations:'. |
 | job.automountServiceAccountToken | bool | `false` | Set automounting of the SA token |
 | job.extraContainers | string | `""` | If you want to add extra sidecar containers. |
-| job.extraEnv | list | `[]` | Array of extra envs to be passed to the job. This takes precedence over deployment variables. Kubernetes format is expected - name: FOO   value: BAR |
+| job.extraEnv | list | `[]` | Array of extra envs to be passed to the job. This takes precedence over deployment variables. Kubernetes format is expected. Value is processed with Helm `tpl` - name: FOO   value: BAR |
 | job.extraInitContainers | string | `""` | If you want to add extra init containers. |
 | job.lifecycle | string | `""` | If you want to add lifecycle hooks. |
 | job.nodeSelector | object | `{}` | Node labels for pod assignment. |

--- a/helm/charts/keto/templates/deployment.yaml
+++ b/helm/charts/keto/templates/deployment.yaml
@@ -102,8 +102,8 @@ spec:
                   key: dsn
               {{- end }}
             {{- end }}
-            {{- with $migrationExtraEnv }}
-              {{- toYaml . | nindent 12 }}
+            {{- if $migrationExtraEnv }}
+              {{- tpl (toYaml $migrationExtraEnv) . | nindent 12 }}
             {{- end }}
           {{- with .Values.keto.automigration.resources }}
           resources:
@@ -195,8 +195,8 @@ spec:
                   key: dsn
               {{- end }}
             {{- end }}
-            {{- with .Values.deployment.extraEnv }}
-              {{- toYaml . | nindent 12 }}
+            {{- if .Values.deployment.extraEnv }}
+              {{- tpl (toYaml .Values.deployment.extraEnv) . | nindent 12 }}
             {{- end }}
           volumeMounts:
             - name: {{ include "keto.name" . }}-config-volume

--- a/helm/charts/keto/values.yaml
+++ b/helm/charts/keto/values.yaml
@@ -81,7 +81,8 @@ job:
   #  - name: ...
   #    image: ...
 
-  # -- Array of extra envs to be passed to the job. This takes precedence over deployment variables. Kubernetes format is expected
+  # -- Array of extra envs to be passed to the job. This takes precedence over deployment variables. Kubernetes format
+  # is expected. Value is processed with Helm `tpl`
   # - name: FOO
   #   value: BAR
   extraEnv: []
@@ -353,7 +354,7 @@ deployment:
   #  - name: ...
   #    image: ...
 
-  # -- Array of extra Envs to be added to the deployment. K8s format expected
+  # -- Array of extra Envs to be added to the deployment. Kubernetes format expected. Value is processed with Helm `tpl`
   # - name: FOO
   #   value: BAR
   extraEnv: []
@@ -406,7 +407,8 @@ deployment:
 
   # -- Parameters for the automigration initContainer
   automigration:
-    # -- Array of extra envs to be passed to the initContainer. Kubernetes format is expected
+    # -- Array of extra envs to be passed to the initContainer. Kubernetes format is expected. Value is processed with
+    # Helm `tpl`
     # - name: FOO
     #   value: BAR
     extraEnv: []

--- a/helm/charts/kratos/README.md
+++ b/helm/charts/kratos/README.md
@@ -31,7 +31,7 @@ A ORY Kratos Helm chart for Kubernetes
 | cronjob.cleanup.affinity | object | `{}` | Configure node affinity |
 | cronjob.cleanup.annotations | object | `{}` | Set custom cron job level annotations |
 | cronjob.cleanup.customArgs | list | `[]` | Configure the arguments of the entrypoint, overriding the default value |
-| cronjob.cleanup.extraEnv | list | `[]` | Array of extra envs to be passed to the cronjob. This takes precedence over deployment variables. Kubernetes format is expected - name: FOO   value: BAR |
+| cronjob.cleanup.extraEnv | list | `[]` | Array of extra envs to be passed to the cronjob. This takes precedence over deployment variables. Kubernetes format is expected. Value is processed with Helm `tpl` - name: FOO   value: BAR |
 | cronjob.cleanup.labels | object | `{}` | Set custom cron job level labels |
 | cronjob.cleanup.nodeSelector | object | `{}` | Configure node labels for pod assignment |
 | cronjob.cleanup.podMetadata | object | `{"annotations":{},"labels":{}}` | Specify pod metadata, this metadata is added directly to the pod, and not higher objects |
@@ -43,7 +43,7 @@ A ORY Kratos Helm chart for Kubernetes
 | deployment.affinity | object | `{}` | Configure node affinity |
 | deployment.annotations | object | `{}` |  |
 | deployment.automigration | object | `{"extraEnv":[]}` | Parameters for the automigration initContainer |
-| deployment.automigration.extraEnv | list | `[]` | Array of extra envs to be passed to the initContainer. Kubernetes format is expected - name: FOO   value: BAR |
+| deployment.automigration.extraEnv | list | `[]` | Array of extra envs to be passed to the initContainer. Kubernetes format is expected. Value is processed with Helm `tpl` - name: FOO   value: BAR |
 | deployment.automountServiceAccountToken | bool | `false` |  |
 | deployment.customLivenessProbe | object | `{}` | Configure a custom livenessProbe. This overwrites the default object |
 | deployment.customReadinessProbe | object | `{}` | Configure a custom readinessProbe. This overwrites the default object |
@@ -51,7 +51,7 @@ A ORY Kratos Helm chart for Kubernetes
 | deployment.dnsConfig | object | `{}` | Configure pod dnsConfig. |
 | deployment.extraArgs | list | `[]` | Array of extra arguments to be passed down to the deployment. Kubernetes args format is expected - --foo - --sqa-opt-out |
 | deployment.extraContainers | string | `""` | If you want to add extra sidecar containers. |
-| deployment.extraEnv | list | `[]` | Array of extra envs to be passed to the deployment. Kubernetes format is expected - name: FOO   value: BAR |
+| deployment.extraEnv | list | `[]` | Array of extra envs to be passed to the deployment. Kubernetes format is expected. Value is processed with Helm `tpl` - name: FOO   value: BAR |
 | deployment.extraInitContainers | string | `""` | If you want to add extra init containers. These are processed before the migration init container. |
 | deployment.extraVolumeMounts | list | `[]` |  |
 | deployment.extraVolumes | list | `[]` | If you want to mount external volume For example, mount a secret containing Certificate root CA to verify database TLS connection. |
@@ -102,7 +102,7 @@ A ORY Kratos Helm chart for Kubernetes
 | job.annotations | object | `{"helm.sh/hook":"pre-install, pre-upgrade","helm.sh/hook-delete-policy":"before-hook-creation,hook-succeeded","helm.sh/hook-weight":"1"}` | If you do want to specify annotations, uncomment the following lines, adjust them as necessary, and remove the curly braces after 'annotations:'. |
 | job.automountServiceAccountToken | bool | `false` | Set automounting of the SA token |
 | job.extraContainers | string | `""` | If you want to add extra sidecar containers. |
-| job.extraEnv | list | `[]` | Array of extra envs to be passed to the job. This takes precedence over deployment variables. Kubernetes format is expected - name: FOO   value: BAR |
+| job.extraEnv | list | `[]` | Array of extra envs to be passed to the job. This takes precedence over deployment variables. Kubernetes format is expected. Value is processed with Helm `tpl` - name: FOO   value: BAR |
 | job.extraInitContainers | string | `""` | If you want to add extra init containers. |
 | job.lifecycle | string | `""` | If you want to add lifecycle hooks. |
 | job.nodeSelector | object | `{}` | Node labels for pod assignment. |
@@ -183,7 +183,7 @@ A ORY Kratos Helm chart for Kubernetes
 | statefulSet.dnsConfig | object | `{}` | Configure pod dnsConfig. |
 | statefulSet.extraArgs | list | `[]` | Array of extra arguments to be passed down to the StatefulSet. Kubernetes args format is expected |
 | statefulSet.extraContainers | string | `""` | If you want to add extra sidecar containers. |
-| statefulSet.extraEnv | list | `[]` |  |
+| statefulSet.extraEnv | list | `[]` | Array of extra envs to be passed to the StatefulSet. This takes precedence over deployment variables. Kubernetes format is expected. Value is processed with Helm `tpl` - name: FOO   value: BAR |
 | statefulSet.extraInitContainers | string | `""` | If you want to add extra init containers. These are processed before the migration init container. |
 | statefulSet.extraVolumeMounts | list | `[]` |  |
 | statefulSet.extraVolumes | list | `[]` | If you want to mount external volume For example, mount a secret containing Certificate root CA to verify database TLS connection. |

--- a/helm/charts/kratos/templates/cleanup-cron-job.yaml
+++ b/helm/charts/kratos/templates/cleanup-cron-job.yaml
@@ -78,8 +78,8 @@ spec:
                       name: {{ include "kratos.secretname" . }}
                       key: dsn
               {{- end }}
-                {{- with $cleanupCronjobExtraEnv }}
-                  {{- toYaml . | nindent 16 }}
+                {{- if $cleanupCronjobExtraEnv }}
+                  {{- tpl (toYaml $cleanupCronjobExtraEnv) . | nindent 16 }}
                 {{- end }}
               resources:
                 {{- toYaml .Values.cronjob.cleanup.resources | nindent 16 }}

--- a/helm/charts/kratos/templates/deployment-kratos.yaml
+++ b/helm/charts/kratos/templates/deployment-kratos.yaml
@@ -93,7 +93,7 @@ spec:
               {{- end }}
             {{- end }}
           {{- if $migrationExtraEnv }}
-            {{- toYaml $migrationExtraEnv | nindent 12 }}
+            {{- tpl (toYaml $migrationExtraEnv) . | nindent 12 }}
           {{- end }}
           {{- with .Values.kratos.automigration.resources }}
           resources:
@@ -194,7 +194,7 @@ spec:
               value: "true"
             {{- end }}
             {{- if .Values.deployment.extraEnv }}
-              {{- toYaml .Values.deployment.extraEnv | nindent 12 }}
+              {{- tpl (toYaml .Values.deployment.extraEnv) . | nindent 12 }}
             {{- end }}
         {{- if .Values.deployment.environmentSecretsName }}
           envFrom:

--- a/helm/charts/kratos/templates/job-migration.yaml
+++ b/helm/charts/kratos/templates/job-migration.yaml
@@ -70,7 +70,7 @@ spec:
             {{- end }}
           {{- end }}
           {{- if $migrationExtraEnv }}
-            {{- toYaml $migrationExtraEnv | nindent 10 }}
+            {{- tpl (toYaml $migrationExtraEnv) . | nindent 10 }}
           {{- end }}
         {{- if .Values.deployment.environmentSecretsName }}
         envFrom:

--- a/helm/charts/kratos/templates/statefulset-mail.yaml
+++ b/helm/charts/kratos/templates/statefulset-mail.yaml
@@ -124,7 +124,7 @@ spec:
                   key: smtpConnectionURI
             {{- end }}
             {{- if $extraEnv }}
-              {{- toYaml $extraEnv | nindent 12 }}
+              {{- tpl (toYaml $extraEnv) . | nindent 12 }}
             {{- end }}
           {{- if $environmentSecretsName }}
           envFrom:

--- a/helm/charts/kratos/values.yaml
+++ b/helm/charts/kratos/values.yaml
@@ -240,7 +240,8 @@ deployment:
   # - --sqa-opt-out
   extraArgs: []
 
-  # -- Array of extra envs to be passed to the deployment. Kubernetes format is expected
+  # -- Array of extra envs to be passed to the deployment. Kubernetes format is expected. Value is processed with Helm
+  # `tpl`
   # - name: FOO
   #   value: BAR
   extraEnv: []
@@ -364,7 +365,8 @@ deployment:
 
   # -- Parameters for the automigration initContainer
   automigration:
-    # -- Array of extra envs to be passed to the initContainer. Kubernetes format is expected
+    # -- Array of extra envs to be passed to the initContainer. Kubernetes format is expected. Value is processed with
+    # Helm `tpl`
     # - name: FOO
     #   value: BAR
     extraEnv: []
@@ -400,6 +402,10 @@ statefulSet:
   # - --foo
   # - --sqa-opt-out
 
+  # -- Array of extra envs to be passed to the StatefulSet. This takes precedence over deployment variables. Kubernetes
+  # format is expected. Value is processed with Helm `tpl`
+  # - name: FOO
+  #   value: BAR
   extraEnv: []
   # -- If you want to mount external volume
   # For example, mount a secret containing Certificate root CA to verify database
@@ -553,7 +559,8 @@ job:
   #  - name: ...
   #    image: ...
 
-  # -- Array of extra envs to be passed to the job. This takes precedence over deployment variables. Kubernetes format is expected
+  # -- Array of extra envs to be passed to the job. This takes precedence over deployment variables. Kubernetes format
+  # is expected. Value is processed with Helm `tpl`
   # - name: FOO
   #   value: BAR
   extraEnv: []
@@ -655,7 +662,8 @@ cronjob:
     # -- Configure the arguments of the entrypoint, overriding the default value
     customArgs: []
 
-    # -- Array of extra envs to be passed to the cronjob. This takes precedence over deployment variables. Kubernetes format is expected
+    # -- Array of extra envs to be passed to the cronjob. This takes precedence over deployment variables. Kubernetes
+    # format is expected. Value is processed with Helm `tpl`
     # - name: FOO
     #   value: BAR
     extraEnv: []

--- a/helm/charts/oathkeeper/README.md
+++ b/helm/charts/oathkeeper/README.md
@@ -40,7 +40,7 @@ A Helm chart for deploying ORY Oathkeeper in Kubernetes
 | deployment.dnsConfig | object | `{}` | Configure pod dnsConfig. |
 | deployment.extraArgs | list | `[]` | Array of extra arguments to be passed down to the Deployment. Kubernetes args format is expected |
 | deployment.extraContainers | string | `""` | If you want to add extra sidecar containers. |
-| deployment.extraEnv | list | `[]` |  |
+| deployment.extraEnv | list | `[]` | Array of extra envs to be passed to the deployment. Kubernetes format is expected. Value is processed with Helm `tpl` - name: FOO   value: BAR |
 | deployment.extraInitContainers | string | `""` | If you want to add extra init containers. |
 | deployment.extraVolumeMounts | list | `[]` | Extra volume mounts, allows mounting the extraVolumes to the container. |
 | deployment.extraVolumes | list | `[]` | Extra volumes you can attach to the pod. |

--- a/helm/charts/oathkeeper/templates/deployment-controller.yaml
+++ b/helm/charts/oathkeeper/templates/deployment-controller.yaml
@@ -116,8 +116,8 @@ spec:
             - name: MUTATORS_ID_TOKEN_CONFIG_JWKS_URL
               value: "file://{{ .Values.secret.mountPath }}/{{ .Values.secret.filename }}"
             {{- end }}
-            {{- with .Values.deployment.extraEnv }}
-              {{- toYaml . | nindent 12 }}
+            {{- if .Values.deployment.extraEnv }}
+              {{- tpl (toYaml .Values.deployment.extraEnv) . | nindent 12 }}
             {{- end }}
           volumeMounts:
           {{- with .Values.deployment.extraVolumeMounts }}

--- a/helm/charts/oathkeeper/templates/deployment-sidecar.yaml
+++ b/helm/charts/oathkeeper/templates/deployment-sidecar.yaml
@@ -96,8 +96,8 @@ spec:
             - name: MUTATORS_ID_TOKEN_CONFIG_JWKS_URL
               value: "file://{{ .Values.secret.mountPath }}/{{ .Values.secret.filename }}"
             {{- end }}
-            {{- with .Values.deployment.extraEnv }}
-              {{- toYaml . | nindent 12 }}
+            {{- if .Values.deployment.extraEnv }}
+              {{- tpl (toYaml .Values.deployment.extraEnv) . | nindent 12 }}
             {{- end }}
           volumeMounts:
             {{- with .Values.deployment.extraVolumeMounts }}

--- a/helm/charts/oathkeeper/values.yaml
+++ b/helm/charts/oathkeeper/values.yaml
@@ -293,6 +293,10 @@ deployment:
   # lines, adjust them as necessary, and remove the curly braces after 'annotations:'.
   #   foo: bar
 
+  # -- Array of extra envs to be passed to the deployment. Kubernetes format is expected. Value is processed with Helm
+  # `tpl`
+  # - name: FOO
+  #   value: BAR
   extraEnv: []
 
   # -- Array of extra arguments to be passed down to the Deployment. Kubernetes args format is expected


### PR DESCRIPTION
Similar to #703, it's useful to be able to template extra environment variables (especially `DSN`). For example, when using several Ory components and multiple environments you can template the DSNs to a shared value instead of needing to set each individually.

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md) and signed the CLA.
- [ ] I have referenced an issue containing the design document if my change introduces a new feature.
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security vulnerability. 
      If this pull request addresses a security vulnerability, 
      I confirm that I got approval (please contact [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push the changes.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added the necessary documentation within the code base (if appropriate).
