### PR TITLE
feat: allow setting env vars for hydra-maester

### DIFF
--- a/helm/charts/hydra-maester/README.md
+++ b/helm/charts/hydra-maester/README.md
@@ -20,6 +20,7 @@ A Helm chart for Kubernetes
 | deployment.automountServiceAccountToken | bool | `true` | This applications connects to the k8s API and requires the permissions |
 | deployment.dnsConfig | object | `{}` | Configure pod dnsConfig. |
 | deployment.extraAnnotations | object | `{}` | Deployment level extra annotations |
+| deployment.extraEnv | list | `[]` | Extra environment variables |
 | deployment.extraLabels | object | `{}` | Deployment level extra labels |
 | deployment.extraVolumeMounts | list | `[]` |  |
 | deployment.extraVolumes | list | `[]` | If you want to mount external volume |

--- a/helm/charts/hydra-maester/templates/deployment.yaml
+++ b/helm/charts/hydra-maester/templates/deployment.yaml
@@ -80,6 +80,10 @@ spec:
             {{- if .Values.deployment.extraVolumeMounts }}
               {{- toYaml .Values.deployment.extraVolumeMounts | nindent 12 }}
             {{- end }}
+          {{- if .Values.deployment.extraEnv }}
+          env:
+            {{- tpl (toYaml .Values.deployment.extraEnv) . | nindent 12 }}
+          {{- end }}
           resources:
             {{- toYaml .Values.deployment.resources | nindent 12 }}
           terminationMessagePath: /dev/termination-log

--- a/helm/charts/hydra-maester/values.yaml
+++ b/helm/charts/hydra-maester/values.yaml
@@ -56,6 +56,9 @@ deployment:
     #   cpu: 100m
     #   memory: 20Mi
 
+  # -- To set extra env vars for the container.
+  extraEnv: []
+
   # -- If you want to mount external volume
   extraVolumes: []
   # - name: my-volume


### PR DESCRIPTION
Add a `deployment.extraEnv` value to the hydra-maester helm chart for setting environment variables.

## Related Issue or Design Document

Fixes #650.

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md) and signed the CLA.
- [x] I have referenced an issue containing the design document if my change introduces a new feature.
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security vulnerability. 
      If this pull request addresses a security vulnerability, 
      I confirm that I got approval (please contact [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push the changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added the necessary documentation within the code base (if appropriate).

## Further comments

I followed the example of the hydra chart, using the same variable name.