### PR TITLE
chore: fix ident in custom migration job

### DIFF
--- a/helm/charts/hydra/templates/job-migrations-custom.yaml
+++ b/helm/charts/hydra/templates/job-migrations-custom.yaml
@@ -43,56 +43,56 @@ spec:
           {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
-      {{- with $.Values.imagePullSecrets }}
+    {{- with $.Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
-      {{- end }}
+    {{- end }}
       serviceAccountName: {{ include "hydra.job.serviceAccountName" $ }}
       automountServiceAccountToken: {{ $.Values.job.automountServiceAccountToken }}
       containers:
-        - name: {{ $.Chart.Name }}-{{ $jobName }}
-          image: "{{ $.Values.image.repository }}:{{ $.Values.image.tag }}"
-          imagePullPolicy: {{ $.Values.image.pullPolicy }}
-        {{- if $job.customCommand }}
-          command: {{- toYaml $job.customCommand | nindent 10 }}
-        {{- else }}
-          command: ["hydra"]
+      - name: {{ $.Chart.Name }}-{{ $jobName }}
+        image: "{{ $.Values.image.repository }}:{{ $.Values.image.tag }}"
+        imagePullPolicy: {{ $.Values.image.pullPolicy }}
+      {{- if $job.customCommand }}
+        command: {{- toYaml $job.customCommand | nindent 10 }}
+      {{- else }}
+        command: ["hydra"]
+      {{- end }}
+        args: {{- toYaml $job.customArgs | nindent 10 }}
+        env:
+        {{- if not (empty ( include "hydra.dsn" $ )) }}
+          {{- if not (include "ory.extraEnvContainsEnvName" (list $migrationExtraEnv "DSN")) }}
+          - name: DSN
+            valueFrom:
+              secretKeyRef:
+                name: {{ include "hydra.secretname" $ }}
+                key: dsn
+          {{- end }}
         {{- end }}
-          args: {{- toYaml $job.customArgs | nindent 10 }}
-          env:
-          {{- if not (empty ( include "hydra.dsn" $ )) }}
-            {{- if not (include "ory.extraEnvContainsEnvName" (list $migrationExtraEnv "DSN")) }}
-            - name: DSN
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "hydra.secretname" $ }}
-                  key: dsn
-            {{- end }}
-          {{- end }}
-          {{- with $migrationExtraEnv }}
-            {{- toYaml . | nindent 10 }}
-          {{- end }}
-          lifecycle:
+        {{- with $migrationExtraEnv }}
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+        lifecycle:
           {{- if $.Values.job.lifecycle }}
             {{- tpl $.Values.job.lifecycle $ | nindent 10 }}
           {{- end }}
         {{- with $.Values.deployment.securityContext }}
-          securityContext:
+        securityContext:
           {{- toYaml . | nindent 10 }}
         {{- end }}
         {{- with $resources }}
-          resources:
+        resources:
           {{- toYaml . | nindent 10 }}
         {{- end }}
-          volumeMounts:
-            - name: {{ include "hydra.name" $ }}-config-volume
-              mountPath: /etc/config
-              readOnly: true
-            {{- if $job.extraVolumeMounts }}
-              {{- toYaml $job.extraVolumeMounts | nindent 12 }}
-            {{- else if $.Values.deployment.extraVolumeMounts }}
-              {{- toYaml $.Values.deployment.extraVolumeMounts | nindent 12 }}
-            {{- end }}
+        volumeMounts:
+          - name: {{ include "hydra.name" $ }}-config-volume
+            mountPath: /etc/config
+            readOnly: true
+          {{- if $job.extraVolumeMounts }}
+            {{- toYaml $job.extraVolumeMounts | nindent 12 }}
+          {{- else if $.Values.deployment.extraVolumeMounts }}
+            {{- toYaml $.Values.deployment.extraVolumeMounts | nindent 12 }}
+          {{- end }}
       {{- if $.Values.job.extraContainers }}
         {{- tpl $.Values.job.extraContainers $ | nindent 6 }}
       {{- end }}


### PR DESCRIPTION
Fixed version:
```
---
# Source: hydra/templates/job-migrations-custom.yaml
apiVersion: batch/v1
kind: Job
metadata:
  name: ory-oel-hydra-oel-postgresql-ttl1
  namespace: oasis
  labels:
    "app.kubernetes.io/name": "hydra"
    "app.kubernetes.io/instance": "ory-oel-hydra"
    "app.kubernetes.io/version": "v2.2.0"
    "app.kubernetes.io/managed-by": "Helm"
    "helm.sh/chart": "hydra-0.50.8"
  annotations:
    helm.sh/hook: pre-install, pre-upgrade
    helm.sh/hook-delete-policy: before-hook-creation
    helm.sh/hook-weight: "1"
spec:
  template:
    metadata:
      annotations:
        helm.sh/hook: pre-install, pre-upgrade
        helm.sh/hook-delete-policy: before-hook-creation
        helm.sh/hook-weight: "1"
      labels:
        app.kubernetes.io/name: ory-oel-hydra-oel-postgresql-ttl1-automigrate
        app.kubernetes.io/instance: ory-oel-hydra
    spec:
      serviceAccountName: ory-oel-hydra-job
      automountServiceAccountToken: true
      containers:
      - name: hydra-oel-postgresql-ttl1
        image: "oryd/hydra:v2.2.0"
        imagePullPolicy: IfNotPresent
        command: ["hydra"]
        args:
          - migrate
          - postgresql-addons
          - up
          - --hydra-db-name
          - ory_hydra
          - --pgcron-db-name
          - postgres
        env:
        lifecycle:
        securityContext:
          allowPrivilegeEscalation: false
          capabilities:
            drop:
            - ALL
          privileged: false
          readOnlyRootFilesystem: true
          runAsGroup: 65534
          runAsNonRoot: true
          runAsUser: 65534
          seLinuxOptions:
            level: s0:c123,c456
          seccompProfile:
            type: RuntimeDefault
        volumeMounts:
          - name: hydra-config-volume
            mountPath: /etc/config
            readOnly: true
      restartPolicy: Never
      securityContext:
        fsGroup: 65534
        fsGroupChangePolicy: OnRootMismatch
        runAsGroup: 65534
        runAsNonRoot: true
        runAsUser: 65534
        seccompProfile:
          type: RuntimeDefault
      shareProcessNamespace: false
      volumes:
        - name: hydra-config-volume
          configMap:
            name: ory-oel-hydra-migrate
  backoffLimit: 10
```