### PR TITLE
feat: allow helm templates in hostnames for hydra

### DIFF
--- a/hacks/values/hydra.yaml
+++ b/hacks/values/hydra.yaml
@@ -1,8 +1,33 @@
+global:
+  dnsDomain: example.com
+
 ingress:
-  public:
-    enabled: true
   admin:
     enabled: true
+    annotations:
+      my.domain: "{{ .Values.global.dnsDomain }}"
+    tls:
+      - secretName: chart-example-tls
+        hosts:
+          - "chart-example.{{ $.Values.global.dnsDomain }}"
+    hosts:
+      - host: "admin.{{ $.Values.global.dnsDomain }}"
+        paths:
+          - path: /
+            pathType: Prefix
+  public:
+    enabled: true
+    annotations:
+      my.domain: "{{ .Values.global.dnsDomain }}"
+    tls:
+      - secretName: chart-example-tls
+        hosts:
+          - "public-chart-example.{{ $.Values.global.dnsDomain }}"
+    hosts:
+      - host: "public.{{ $.Values.global.dnsDomain }}"
+        paths:
+          - path: /
+            pathType: Prefix
 
 hydra:
   automigration:

--- a/helm/charts/hydra/templates/_helpers.tpl
+++ b/helm/charts/hydra/templates/_helpers.tpl
@@ -133,10 +133,10 @@ Generate the urls.issuer value
 */}}
 {{- define "hydra.config.urls.issuer" -}}
 {{- if .Values.hydra.config.urls.self.issuer -}}
-{{- .Values.hydra.config.urls.self.issuer }}
+{{- tpl .Values.hydra.config.urls.self.issuer $ }}
 {{- else if .Values.ingress.public.enabled -}}
 {{- $host := index .Values.ingress.public.hosts 0 -}}
-http{{ if $.Values.ingress.public.tls }}s{{ end }}://{{ $host.host }}
+http{{ if $.Values.ingress.public.tls }}s{{ end }}://{{ tpl $host.host $ }}
 {{- else if contains "ClusterIP" .Values.service.public.type -}}
 http://127.0.0.1:{{ .Values.service.public.port }}/
 {{- end -}}

--- a/helm/charts/hydra/templates/ingress-admin.yaml
+++ b/helm/charts/hydra/templates/ingress-admin.yaml
@@ -15,7 +15,7 @@ metadata:
     {{- include "hydra.labels" . | nindent 4 }}
   {{- with .Values.ingress.admin.annotations }}
   annotations:
-    {{- toYaml . | nindent 4 }}
+    {{- tpl (toYaml .) $ | nindent 4 }}
   {{- end }}
 spec:
   ingressClassName: {{ .Values.ingress.admin.className }}
@@ -24,14 +24,14 @@ spec:
     {{- range .Values.ingress.admin.tls }}
     - hosts:
         {{- range .hosts }}
-        - {{ . | quote }}
+        - {{ tpl . $ | quote }}
         {{- end }}
       secretName: {{ .secretName }}
     {{- end }}
   {{- end }}
   rules:
     {{- range .Values.ingress.admin.hosts }}
-    - host: {{ .host | quote }}
+    - host: {{ tpl .host $ | quote }}
       http:
         paths:
           {{- range .paths }}

--- a/helm/charts/hydra/templates/ingress-public.yaml
+++ b/helm/charts/hydra/templates/ingress-public.yaml
@@ -15,7 +15,7 @@ metadata:
     {{- include "hydra.labels" . | nindent 4 }}
   {{- with .Values.ingress.public.annotations }}
   annotations:
-    {{- toYaml . | nindent 4 }}
+    {{- tpl (toYaml .) $ | nindent 4 }}
   {{- end }}
 spec:
   ingressClassName: {{ .Values.ingress.public.className }}
@@ -24,14 +24,14 @@ spec:
     {{- range .Values.ingress.public.tls }}
     - hosts:
         {{- range .hosts }}
-        - {{ . | quote }}
+        - {{ tpl . $ | quote }}
         {{- end }}
       secretName: {{ .secretName }}
-    {{- end }}  
+    {{- end }}
   {{- end }}
   rules:
     {{- range .Values.ingress.public.hosts }}
-    - host: {{ .host | quote }}
+    - host: {{ tpl .host $ | quote }}
       http:
         paths:
           {{- range .paths }}


### PR DESCRIPTION
This PR will implement:

- helm templating of hostname in admin and public Ingress Resources for Hydra helm chart.
- helm templating of issuer as derived in _hydra.config.urls.issuer_ .

Note: 
Helm templating in ingress resources is already implemented in Kratos chart. This PR basically transfers all logic from the Kratos Ingress template to the Hydra chart.

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md) and signed the CLA.
- [ ] I have referenced an issue containing the design document if my change introduces a new feature.
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security vulnerability. 
      If this pull request addresses a security vulnerability, 
      I confirm that I got approval (please contact [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push the changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added the necessary documentation within the code base (if appropriate).
