### PR TITLE
docs: reflect that oathkeeper maester is disabled by default

### DIFF
--- a/docs/helm/oathkeeper.md
+++ b/docs/helm/oathkeeper.md
@@ -176,12 +176,12 @@ This chart includes a helper chart in the form of
 [Oathkeeper-maester](https://github.com/ory/k8s/blob/master/docs/helm/oathkeeper-maester.md),
 a k8s controller, which translates access rules object into a kubernetes native
 [CustomResource](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/).
-This component is enabled by default, and installed together with Oathkeeper,
-however it can be disabled by setting the proper flag:
+This component is disabled by default, but can be enabled by setting the proper
+flag:
 
 ```bash
 $ helm install \
-    --set 'maester.enabled=false' \
+    --set 'maester.enabled=true' \
     ory/oathkeeper
 ```
 


### PR DESCRIPTION
In https://github.com/ory/k8s/commit/defbd626ad1f5357119b111a9a45d9a0dc2020e5 the behaviour of the oathkeeper chart was changed so that oathkeeper maester is disabled by default, this PR updates the docs to reflect this.

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md) and signed the CLA.
- [ ] I have referenced an issue containing the design document if my change introduces a new feature.
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security vulnerability. 
      If this pull request addresses a security vulnerability, 
      I confirm that I got approval (please contact [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push the changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added the necessary documentation within the code base (if appropriate).

