### PR TITLE
fix: helm hooks can be opt-out on ory components

### DIFF
--- a/helm/charts/hydra/README.md
+++ b/helm/charts/hydra/README.md
@@ -174,7 +174,9 @@ A Helm chart for deploying ORY Hydra in Kubernetes
 | pdb.spec.minAvailable | string | `""` |  |
 | priorityClassName | string | `""` | Pod priority https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/ |
 | replicaCount | int | `1` | Number of ORY Hydra members |
+| secret.enableDefaultAnnotations | bool | `true` | enableDefaultAnnotations set to `true` will add default annotations to the secret. As such the Secret will be managed by helm hooks. |
 | secret.enabled | bool | `true` | switch to false to prevent creating the secret |
+| secret.extraAnnotations | object | `{}` | extraAnnotations to be added to secret. |
 | secret.hashSumEnabled | bool | `true` | switch to false to prevent checksum annotations being maintained and propogated to the pods |
 | secret.nameOverride | string | `""` | Provide custom name of existing secret, or custom name of secret to be created |
 | secret.secretAnnotations | object | `{"helm.sh/hook":"pre-install, pre-upgrade","helm.sh/hook-delete-policy":"before-hook-creation","helm.sh/hook-weight":"0","helm.sh/resource-policy":"keep"}` | Annotations to be added to secret. Annotations are added only when secret is being created. Existing secret will not be modified. |

--- a/helm/charts/hydra/templates/_helpers.tpl
+++ b/helm/charts/hydra/templates/_helpers.tpl
@@ -83,6 +83,18 @@ Generate the name of the secret resource containing secrets
 {{- end -}}
 
 {{/*
+Generate the secrets.annotations value
+*/}}
+{{- define "hydra.secrets.annotations" -}}
+  {{- $annotations := dict -}}
+  {{- if .Values.secret.enableDefaultAnnotations }}
+    {{- $annotations = .Values.secret.secretAnnotations -}}
+  {{- end -}}
+  {{- $annotations = merge $annotations .Values.secret.extraAnnotations -}}
+  {{- toYaml $annotations }}
+{{- end -}}
+
+{{/*
 Generate the secrets.system value
 */}}
 {{- define "hydra.secrets.system" -}}

--- a/helm/charts/hydra/templates/secrets.yaml
+++ b/helm/charts/hydra/templates/secrets.yaml
@@ -8,10 +8,8 @@ metadata:
   {{- end }}
   labels:
     {{- include "hydra.labels" . | nindent 4 }}
-  annotations:
-    {{- with .Values.secret.secretAnnotations }}
-      {{- toYaml . | nindent 4 }}
-    {{- end }}
+  annotations: 
+    {{- include "hydra.secrets.annotations" . | nindent 4 }}
 type: Opaque
 data:
   # Generate a random secret if the user doesn't give one. User given password has priority

--- a/helm/charts/hydra/values.yaml
+++ b/helm/charts/hydra/values.yaml
@@ -65,13 +65,15 @@ service:
     # -- Path to the metrics endpoint
     metricsPath: /admin/metrics/prometheus
 
-## -- Secret management
+## -- Secret configuration
 secret:
   # -- switch to false to prevent creating the secret
   enabled: true
   # -- Provide custom name of existing secret, or custom name of secret to be created
   nameOverride: ""
   # nameOverride: "myCustomSecret"
+  # -- enableDefaultAnnotations set to `true` will add default annotations to the secret. As such the Secret will be managed by helm hooks.
+  enableDefaultAnnotations: true
   # -- Annotations to be added to secret. Annotations are added only when secret is being created. Existing secret will not be modified.
   secretAnnotations:
     # Create the secret before installation, and only then. This saves the secret from regenerating during an upgrade
@@ -80,6 +82,8 @@ secret:
     helm.sh/hook: "pre-install, pre-upgrade"
     helm.sh/hook-delete-policy: "before-hook-creation"
     helm.sh/resource-policy: "keep"
+  # -- extraAnnotations to be added to secret.
+  extraAnnotations: {}
   # -- switch to false to prevent checksum annotations being maintained and propogated to the pods
   hashSumEnabled: true
 

--- a/helm/charts/keto/README.md
+++ b/helm/charts/keto/README.md
@@ -128,7 +128,9 @@ Access Control Policies as a Server
 | podSecurityContext.seccompProfile.type | string | `"RuntimeDefault"` |  |
 | priorityClassName | string | `""` | Pod priority https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/ |
 | replicaCount | int | `1` | Number of replicas in deployment |
-| secret.enabled | bool | `true` | Switch to false to prevent creating the secret |
+| secret.enableDefaultAnnotations | bool | `true` | enableDefaultAnnotations set to `true` will add default annotations to the secret. As such the Secret will be managed by helm hooks. |
+| secret.enabled | bool | `true` | switch to false to prevent creating the secret |
+| secret.extraAnnotations | object | `{}` | extraAnnotations to be added to secret. |
 | secret.hashSumEnabled | bool | `true` | switch to false to prevent checksum annotations being maintained and propogated to the pods |
 | secret.nameOverride | string | `""` | Provide custom name of existing secret, or custom name of secret to be created |
 | secret.secretAnnotations | object | `{"helm.sh/hook":"pre-install, pre-upgrade","helm.sh/hook-delete-policy":"before-hook-creation","helm.sh/hook-weight":"0","helm.sh/resource-policy":"keep"}` | Annotations to be added to secret. Annotations are added only when secret is being created. Existing secret will not be modified. |

--- a/helm/charts/keto/templates/_helpers.tpl
+++ b/helm/charts/keto/templates/_helpers.tpl
@@ -42,6 +42,18 @@ Create chart name and version as used by the chart label.
 {{- end }}
 
 {{/*
+Generate the secrets.annotations value
+*/}}
+{{- define "keto.secrets.annotations" -}}
+  {{- $annotations := dict -}}
+  {{- if .Values.secret.enableDefaultAnnotations }}
+    {{- $annotations = .Values.secret.secretAnnotations -}}
+  {{- end -}}
+  {{- $annotations = merge $annotations .Values.secret.extraAnnotations -}}
+  {{- toYaml $annotations }}
+{{- end -}}
+
+{{/*
 Generate the dsn value
 */}}
 {{- define "keto.dsn" -}}

--- a/helm/charts/keto/templates/secrets.yaml
+++ b/helm/charts/keto/templates/secrets.yaml
@@ -8,10 +8,8 @@ metadata:
   {{- end }}
   labels:
 {{ include "keto.labels" . | indent 4 }}
-  annotations:
-{{- with .Values.secret.secretAnnotations }}
-  {{- toYaml . | nindent 4 }}
-{{- end }}
+  annotations: 
+{{- include "keto.secrets.annotations" . | nindent 4 }}
 type: Opaque
 data:
   dsn: {{ include "keto.dsn" . | b64enc | quote }}

--- a/helm/charts/keto/values.yaml
+++ b/helm/charts/keto/values.yaml
@@ -217,13 +217,15 @@ service:
 ## -- Extra services to be deployed
 extraServices: {}
 
-## -- Secret management
+## -- Secret configuration
 secret:
-  # -- Switch to false to prevent creating the secret
+  # -- switch to false to prevent creating the secret
   enabled: true
   # -- Provide custom name of existing secret, or custom name of secret to be created
   nameOverride: ""
   # nameOverride: "myCustomSecret"
+  # -- enableDefaultAnnotations set to `true` will add default annotations to the secret. As such the Secret will be managed by helm hooks.
+  enableDefaultAnnotations: true
   # -- Annotations to be added to secret. Annotations are added only when secret is being created. Existing secret will not be modified.
   secretAnnotations:
     # Create the secret before installation, and only then. This saves the secret from regenerating during an upgrade
@@ -232,6 +234,8 @@ secret:
     helm.sh/hook: "pre-install, pre-upgrade"
     helm.sh/hook-delete-policy: "before-hook-creation"
     helm.sh/resource-policy: "keep"
+  # -- extraAnnotations to be added to secret.
+  extraAnnotations: {}
   # -- switch to false to prevent checksum annotations being maintained and propogated to the pods
   hashSumEnabled: true
 

--- a/helm/charts/kratos-selfservice-ui-node/README.md
+++ b/helm/charts/kratos-selfservice-ui-node/README.md
@@ -50,7 +50,9 @@ A Helm chart for ORY Kratos's example ui for Kubernetes
 | projectName | string | `"SecureApp"` |  |
 | replicaCount | int | `1` | Number of replicas in deployment |
 | revisionHistoryLimit | int | `5` | Number of revisions kept in history |
+| secret.enableDefaultAnnotations | bool | `true` | enableDefaultAnnotations set to `true` will add default annotations to the secret. As such the Secret will be managed by helm hooks. |
 | secret.enabled | bool | `true` | switch to false to prevent creating the secret |
+| secret.extraAnnotations | object | `{}` | extraAnnotations to be added to secret. |
 | secret.hashSumEnabled | bool | `true` | switch to false to prevent checksum annotations being maintained and propogated to the pods |
 | secret.nameOverride | string | `""` | Provide custom name of existing secret, or custom name of secret to be created |
 | secret.secretAnnotations | object | `{"helm.sh/hook":"pre-install, pre-upgrade","helm.sh/hook-delete-policy":"before-hook-creation","helm.sh/hook-weight":"0","helm.sh/resource-policy":"keep"}` | Annotations to be added to secret. Annotations are added only when secret is being created. Existing secret will not be modified. |

--- a/helm/charts/kratos-selfservice-ui-node/templates/_helpers.tpl
+++ b/helm/charts/kratos-selfservice-ui-node/templates/_helpers.tpl
@@ -54,3 +54,15 @@ Create a secret name which can be overridden.
 {{ include "kratos-selfservice-ui-node.fullname" . }}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Generate the secrets.annotations value
+*/}}
+{{- define "kratos-selfservice-ui-node.secrets.annotations" -}}
+  {{- $annotations := dict -}}
+  {{- if .Values.secret.enableDefaultAnnotations }}
+    {{- $annotations = .Values.secret.secretAnnotations -}}
+  {{- end -}}
+  {{- $annotations = merge $annotations .Values.secret.extraAnnotations -}}
+  {{- toYaml $annotations }}
+{{- end -}}

--- a/helm/charts/kratos-selfservice-ui-node/templates/secret.yaml
+++ b/helm/charts/kratos-selfservice-ui-node/templates/secret.yaml
@@ -8,10 +8,8 @@ metadata:
   {{- end }}
   labels:
     {{- include "kratos-selfservice-ui-node.labels" . | nindent 4 }}
-  annotations:
-    {{- with .Values.secret.secretAnnotations }}
-      {{- toYaml . | nindent 4 }}
-    {{- end }}
+  annotations: 
+    {{- include "kratos-selfservice-ui-node.secrets.annotations" . | nindent 4 }}
 type: Opaque
 data:
   # Generate a random secret if the user doesn't give one. User given secret has priority

--- a/helm/charts/kratos-selfservice-ui-node/values.yaml
+++ b/helm/charts/kratos-selfservice-ui-node/values.yaml
@@ -48,6 +48,8 @@ secret:
   # -- Provide custom name of existing secret, or custom name of secret to be created
   nameOverride: ""
   # nameOverride: "myCustomSecret"
+  # -- enableDefaultAnnotations set to `true` will add default annotations to the secret. As such the Secret will be managed by helm hooks.
+  enableDefaultAnnotations: true
   # -- Annotations to be added to secret. Annotations are added only when secret is being created. Existing secret will not be modified.
   secretAnnotations:
     # Create the secret before installation, and only then. This saves the secret from regenerating during an upgrade
@@ -56,6 +58,8 @@ secret:
     helm.sh/hook: "pre-install, pre-upgrade"
     helm.sh/hook-delete-policy: "before-hook-creation"
     helm.sh/resource-policy: "keep"
+  # -- extraAnnotations to be added to secret.
+  extraAnnotations: {}
   # -- switch to false to prevent checksum annotations being maintained and propogated to the pods
   hashSumEnabled: true
 

--- a/helm/charts/kratos/README.md
+++ b/helm/charts/kratos/README.md
@@ -134,7 +134,9 @@ A ORY Kratos Helm chart for Kubernetes
 | pdb.spec.maxUnavailable | string | `""` |  |
 | pdb.spec.minAvailable | string | `""` |  |
 | replicaCount | int | `1` | Number of replicas in deployment |
+| secret.enableDefaultAnnotations | bool | `true` | enableDefaultAnnotations set to `true` will add default annotations to the secret. As such the Secret will be managed by helm hooks. |
 | secret.enabled | bool | `true` | switch to false to prevent creating the secret |
+| secret.extraAnnotations | object | `{}` | extraAnnotations to be added to secret. |
 | secret.hashSumEnabled | bool | `true` | switch to false to prevent checksum annotations being maintained and propogated to the pods |
 | secret.nameOverride | string | `""` | Provide custom name of existing secret, or custom name of secret to be created |
 | secret.secretAnnotations | object | `{"helm.sh/hook":"pre-install, pre-upgrade","helm.sh/hook-delete-policy":"before-hook-creation","helm.sh/hook-weight":"0","helm.sh/resource-policy":"keep"}` | Annotations to be added to secret. Annotations are added only when secret is being created. Existing secret will not be modified. |

--- a/helm/charts/kratos/templates/_helpers.tpl
+++ b/helm/charts/kratos/templates/_helpers.tpl
@@ -43,6 +43,18 @@ Create chart name and version as used by the chart label.
 {{- end -}}
 
 {{/*
+Generate the secrets.annotations value
+*/}}
+{{- define "kratos.secrets.annotations" -}}
+  {{- $annotations := dict -}}
+  {{- if .Values.secret.enableDefaultAnnotations }}
+    {{- $annotations = .Values.secret.secretAnnotations -}}
+  {{- end -}}
+  {{- $annotations = merge $annotations .Values.secret.extraAnnotations -}}
+  {{- toYaml $annotations }}
+{{- end -}}
+
+{{/*
 Generate the dsn value
 */}}
 {{- define "kratos.dsn" -}}

--- a/helm/charts/kratos/templates/secrets.yaml
+++ b/helm/charts/kratos/templates/secrets.yaml
@@ -8,10 +8,8 @@ metadata:
   {{- end }}
   labels:
 {{ include "kratos.labels" . | indent 4 }}
-  annotations:
-{{- with .Values.secret.secretAnnotations }}
-  {{- toYaml . | nindent 4 }}
-{{- end }}
+  annotations: 
+  {{- include "kratos.secrets.annotations" . | nindent 4 }}
 type: Opaque
 data:
   dsn: {{ include "kratos.dsn" . | b64enc | quote }}

--- a/helm/charts/kratos/values.yaml
+++ b/helm/charts/kratos/values.yaml
@@ -75,13 +75,15 @@ service:
     # -- Path to the metrics endpoint
     metricsPath: /metrics/prometheus
 
-## -- Secret management
+## -- Secret configuration
 secret:
   # -- switch to false to prevent creating the secret
   enabled: true
   # -- Provide custom name of existing secret, or custom name of secret to be created
   nameOverride: ""
   # nameOverride: "myCustomSecret"
+  # -- enableDefaultAnnotations set to `true` will add default annotations to the secret. As such the Secret will be managed by helm hooks.
+  enableDefaultAnnotations: true
   # -- Annotations to be added to secret. Annotations are added only when secret is being created. Existing secret will not be modified.
   secretAnnotations:
     # Create the secret before installation, and only then. This saves the secret from regenerating during an upgrade
@@ -90,6 +92,8 @@ secret:
     helm.sh/hook: "pre-install, pre-upgrade"
     helm.sh/hook-delete-policy: "before-hook-creation"
     helm.sh/resource-policy: "keep"
+  # -- extraAnnotations to be added to secret.
+  extraAnnotations: {}
   # -- switch to false to prevent checksum annotations being maintained and propogated to the pods
   hashSumEnabled: true
 

--- a/helm/charts/oathkeeper/README.md
+++ b/helm/charts/oathkeeper/README.md
@@ -103,7 +103,9 @@ A Helm chart for deploying ORY Oathkeeper in Kubernetes
 | priorityClassName | string | `""` | Pod priority https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/ |
 | replicaCount | int | `1` | Number of ORY Oathkeeper members |
 | revisionHistoryLimit | int | `5` | Number of revisions kept in history |
+| secret.enableDefaultAnnotations | bool | `true` | enableDefaultAnnotations set to `true` will add default annotations to the secret. As such the Secret will be managed by helm hooks. |
 | secret.enabled | bool | `false` | Switch to false to prevent using mutatorIdTokenJWKs secret |
+| secret.extraAnnotations | object | `{}` | extraAnnotations to be added to secret. |
 | secret.filename | string | `"mutator.id_token.jwks.json"` | default filename of JWKS (mounted as secret) |
 | secret.hashSumEnabled | bool | `true` | switch to false to prevent checksum annotations being maintained and propogated to the pods |
 | secret.mountPath | string | `"/etc/secrets"` | default mount path for the kubernetes secret |

--- a/helm/charts/oathkeeper/templates/_helpers.tpl
+++ b/helm/charts/oathkeeper/templates/_helpers.tpl
@@ -136,3 +136,15 @@ checksum/oathkeeper-rules: {{ include (print $.Template.BasePath "/configmap-rul
 checksum/oauthkeeper-secrets: {{ include (print $.Template.BasePath "/secrets.yaml") . | sha256sum }}
 {{- end }}
 {{- end }}
+
+{{/*
+Generate the secrets.annotations value
+*/}}
+{{- define "oathkeeper.secrets.annotations" -}}
+  {{- $annotations := dict -}}
+  {{- if .Values.secret.enableDefaultAnnotations }}
+    {{- $annotations = .Values.secret.secretAnnotations -}}
+  {{- end -}}
+  {{- $annotations = merge $annotations .Values.secret.extraAnnotations -}}
+  {{- toYaml $annotations }}
+{{- end -}}

--- a/helm/charts/oathkeeper/templates/secrets.yaml
+++ b/helm/charts/oathkeeper/templates/secrets.yaml
@@ -8,10 +8,8 @@ metadata:
   {{- end }}
   labels:
 {{ include "oathkeeper.labels" . | indent 4 }}
-  annotations:
-{{- with .Values.secret.secretAnnotations }}
-  {{- toYaml . | nindent 4 }}
-{{- end }}
+  annotations: 
+    {{- include "oathkeeper.secrets.annotations" . | nindent 4 }}
 type: Opaque
 data:
   "{{ .Values.secret.filename }}": {{ default "" .Values.oathkeeper.mutatorIdTokenJWKs | b64enc | quote }}

--- a/helm/charts/oathkeeper/values.yaml
+++ b/helm/charts/oathkeeper/values.yaml
@@ -227,6 +227,8 @@ secret:
   # -- Provide custom name of existing secret if oathkeeper.mutatorIdTokenJWKs is left empty, or custom name of secret to be created
   nameOverride: ""
   # nameOverride: "myCustomSecret"
+  # -- enableDefaultAnnotations set to `true` will add default annotations to the secret. As such the Secret will be managed by helm hooks.
+  enableDefaultAnnotations: true
   # -- Annotations to be added to secret. Annotations are added only when secret is being created. Existing secret will not be modified.
   secretAnnotations:
     # Create the secret before installation, and only then. This saves the secret from regenerating during an upgrade
@@ -235,7 +237,8 @@ secret:
     helm.sh/hook: "pre-install, pre-upgrade"
     helm.sh/hook-delete-policy: "before-hook-creation"
     helm.sh/resource-policy: "keep"
-
+  # -- extraAnnotations to be added to secret.
+  extraAnnotations: {}
   # -- default mount path for the kubernetes secret
   mountPath: /etc/secrets
   # -- default filename of JWKS (mounted as secret)


### PR DESCRIPTION
Helm hooks can be easily opt-out from any ory component's charts when creating Kubernetes Secret.

## Related Issue or Design Document

#770 

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md) and signed the CLA.
- [x] I have referenced an issue containing the design document if my change introduces a new feature.
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security vulnerability. 
      If this pull request addresses a security vulnerability, 
      I confirm that I got approval (please contact [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push the changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added the necessary documentation within the code base (if appropriate).

## Further comments

N/A
