### PR TITLE
fix: user correct hydra-maester chart version

### DIFF
--- a/helm/charts/hydra-maester/Chart.yaml
+++ b/helm/charts/hydra-maester/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: "v0.0.36"
+appVersion: "v0.0.37"
 description: A Helm chart for Kubernetes
 name: hydra-maester
 icon: https://raw.githubusercontent.com/ory/docs/master/docs/static/img/logo-hydra.svg


### PR DESCRIPTION
The version of the hydra maester chart is not consistent, it remains at v0.0.36 whereas the version of hydra mester is v0.0.37.

## Related PR

to complete this PR : https://github.com/ory/k8s/pull/774

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md) and signed the CLA.
- [x] I have referenced an issue containing the design document if my change introduces a new feature.
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security vulnerability. 
      If this pull request addresses a security vulnerability, 
      I confirm that I got approval (please contact [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push the changes.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added the necessary documentation within the code base (if appropriate).

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
