### PR TITLE
chore(deps): appVersion

### DIFF
--- a/helm/charts/kratos/Chart.yaml
+++ b/helm/charts/kratos/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: "v1.3.0"
+appVersion: "v1.3.1"
 description: A ORY Kratos Helm chart for Kubernetes
 name: kratos
 icon: https://raw.githubusercontent.com/ory/docs/master/docs/static/img/logo-kratos.svg


### PR DESCRIPTION
I wanted to update kratos to 1.3.1, but then saw only the appVersion is not up to date yet.

Minor nitpick.
