### PR TITLE
feat: add relabeling and metricRelabeling in serviceMonitor for all helm charts

### DIFF
--- a/hacks/values/hydra-maester/default.yaml
+++ b/hacks/values/hydra-maester/default.yaml
@@ -38,3 +38,13 @@ serviceMonitor:
     release: "prometheus"
   tlsConfig:
     insecureSkipVerify: true
+  relabelings:
+  - source_labels: [__address__]
+    regex: '([^:]+):.*'
+    target_label: instance
+    replacement: '$1'
+  metricRelabelings:
+  - source_labels: [__address__]
+    regex: '([^:]+):.*'
+    target_label: instance
+    replacement: '$1'

--- a/hacks/values/hydra-maester/default.yaml
+++ b/hacks/values/hydra-maester/default.yaml
@@ -39,12 +39,12 @@ serviceMonitor:
   tlsConfig:
     insecureSkipVerify: true
   relabelings:
-  - source_labels: [__address__]
-    regex: '([^:]+):.*'
-    target_label: instance
-    replacement: '$1'
+    - source_labels: [__address__]
+      regex: '([^:]+):.*'
+      target_label: instance
+      replacement: '$1'
   metricRelabelings:
-  - source_labels: [__address__]
-    regex: '([^:]+):.*'
-    target_label: instance
-    replacement: '$1'
+    - source_labels: [__address__]
+      regex: '([^:]+):.*'
+      target_label: instance
+      replacement: '$1'

--- a/hacks/values/hydra-maester/default.yaml
+++ b/hacks/values/hydra-maester/default.yaml
@@ -40,11 +40,11 @@ serviceMonitor:
     insecureSkipVerify: true
   relabelings:
     - source_labels: [__address__]
-      regex: '([^:]+):.*'
+      regex: "([^:]+):.*"
       target_label: instance
-      replacement: '$1'
+      replacement: "$1"
   metricRelabelings:
     - source_labels: [__address__]
-      regex: '([^:]+):.*'
+      regex: "([^:]+):.*"
       target_label: instance
-      replacement: '$1'
+      replacement: "$1"

--- a/hacks/values/hydra/default.yaml
+++ b/hacks/values/hydra/default.yaml
@@ -191,14 +191,14 @@ serviceMonitor:
     insecureSkipVerify: true
   relabelings:
     - source_labels: [__address__]
-      regex: '([^:]+):.*'
+      regex: "([^:]+):.*"
       target_label: instance
-      replacement: '$1'
+      replacement: "$1"
   metricRelabelings:
     - source_labels: [__address__]
-      regex: '([^:]+):.*'
+      regex: "([^:]+):.*"
       target_label: instance
-      replacement: '$1'
+      replacement: "$1"
 
 cronjob:
   janitor:

--- a/hacks/values/hydra/default.yaml
+++ b/hacks/values/hydra/default.yaml
@@ -189,6 +189,16 @@ serviceMonitor:
     release: "prometheus"
   tlsConfig:
     insecureSkipVerify: true
+  relabelings:
+  - source_labels: [__address__]
+    regex: '([^:]+):.*'
+    target_label: instance
+    replacement: '$1'
+  metricRelabelings:
+  - source_labels: [__address__]
+    regex: '([^:]+):.*'
+    target_label: instance
+    replacement: '$1'
 
 cronjob:
   janitor:

--- a/hacks/values/hydra/default.yaml
+++ b/hacks/values/hydra/default.yaml
@@ -190,15 +190,15 @@ serviceMonitor:
   tlsConfig:
     insecureSkipVerify: true
   relabelings:
-  - source_labels: [__address__]
-    regex: '([^:]+):.*'
-    target_label: instance
-    replacement: '$1'
+    - source_labels: [__address__]
+      regex: '([^:]+):.*'
+      target_label: instance
+      replacement: '$1'
   metricRelabelings:
-  - source_labels: [__address__]
-    regex: '([^:]+):.*'
-    target_label: instance
-    replacement: '$1'
+    - source_labels: [__address__]
+      regex: '([^:]+):.*'
+      target_label: instance
+      replacement: '$1'
 
 cronjob:
   janitor:

--- a/hacks/values/keto/default.yaml
+++ b/hacks/values/keto/default.yaml
@@ -127,15 +127,15 @@ serviceMonitor:
   tlsConfig:
     insecureSkipVerify: true
   relabelings:
-  - source_labels: [__address__]
-    regex: '([^:]+):.*'
-    target_label: instance
-    replacement: '$1'
+    - source_labels: [__address__]
+      regex: '([^:]+):.*'
+      target_label: instance
+      replacement: '$1'
   metricRelabelings:
-  - source_labels: [__address__]
-    regex: '([^:]+):.*'
-    target_label: instance
-    replacement: '$1'
+    - source_labels: [__address__]
+      regex: '([^:]+):.*'
+      target_label: instance
+      replacement: '$1'
 
 test:
   labels:

--- a/hacks/values/keto/default.yaml
+++ b/hacks/values/keto/default.yaml
@@ -128,14 +128,14 @@ serviceMonitor:
     insecureSkipVerify: true
   relabelings:
     - source_labels: [__address__]
-      regex: '([^:]+):.*'
+      regex: "([^:]+):.*"
       target_label: instance
-      replacement: '$1'
+      replacement: "$1"
   metricRelabelings:
     - source_labels: [__address__]
-      regex: '([^:]+):.*'
+      regex: "([^:]+):.*"
       target_label: instance
-      replacement: '$1'
+      replacement: "$1"
 
 test:
   labels:

--- a/hacks/values/keto/default.yaml
+++ b/hacks/values/keto/default.yaml
@@ -126,6 +126,16 @@ serviceMonitor:
     release: "prometheus"
   tlsConfig:
     insecureSkipVerify: true
+  relabelings:
+  - source_labels: [__address__]
+    regex: '([^:]+):.*'
+    target_label: instance
+    replacement: '$1'
+  metricRelabelings:
+  - source_labels: [__address__]
+    regex: '([^:]+):.*'
+    target_label: instance
+    replacement: '$1'
 
 test:
   labels:

--- a/hacks/values/kratos/default.yaml
+++ b/hacks/values/kratos/default.yaml
@@ -381,15 +381,15 @@ serviceMonitor:
   tlsConfig:
     insecureSkipVerify: true
   relabelings:
-  - source_labels: [__address__]
-    regex: '([^:]+):.*'
-    target_label: instance
-    replacement: '$1'
+    - source_labels: [__address__]
+      regex: '([^:]+):.*'
+      target_label: instance
+      replacement: '$1'
   metricRelabelings:
-  - source_labels: [__address__]
-    regex: '([^:]+):.*'
-    target_label: instance
-    replacement: '$1'
+    - source_labels: [__address__]
+      regex: '([^:]+):.*'
+      target_label: instance
+      replacement: '$1'
 
 test:
   busybox:

--- a/hacks/values/kratos/default.yaml
+++ b/hacks/values/kratos/default.yaml
@@ -380,6 +380,16 @@ serviceMonitor:
     release: "prometheus"
   tlsConfig:
     insecureSkipVerify: true
+  relabelings:
+  - source_labels: [__address__]
+    regex: '([^:]+):.*'
+    target_label: instance
+    replacement: '$1'
+  metricRelabelings:
+  - source_labels: [__address__]
+    regex: '([^:]+):.*'
+    target_label: instance
+    replacement: '$1'
 
 test:
   busybox:

--- a/hacks/values/kratos/default.yaml
+++ b/hacks/values/kratos/default.yaml
@@ -382,14 +382,14 @@ serviceMonitor:
     insecureSkipVerify: true
   relabelings:
     - source_labels: [__address__]
-      regex: '([^:]+):.*'
+      regex: "([^:]+):.*"
       target_label: instance
-      replacement: '$1'
+      replacement: "$1"
   metricRelabelings:
     - source_labels: [__address__]
-      regex: '([^:]+):.*'
+      regex: "([^:]+):.*"
       target_label: instance
-      replacement: '$1'
+      replacement: "$1"
 
 test:
   busybox:

--- a/helm/charts/hydra-maester/README.md
+++ b/helm/charts/hydra-maester/README.md
@@ -72,6 +72,8 @@ A Helm chart for Kubernetes
 | service.metrics.port | int | `8080` |  |
 | service.metrics.type | string | `"ClusterIP"` |  |
 | serviceMonitor.labels | object | `{}` | Provide additional labels to the ServiceMonitor resource metadata |
+| serviceMonitor.metricRelabelings | list | `[]` | Metric relabeling is applied to samples as the last step before ingestion. Reference: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#metric_relabel_configs |
+| serviceMonitor.relabelings | list | `[]` | Relabeling is a powerful tool to dynamically rewrite the label set of a target before it gets scraped. Reference: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config |
 | serviceMonitor.scheme | string | `"http"` | HTTP scheme to use for scraping. |
 | serviceMonitor.scrapeInterval | string | `"60s"` | Interval at which metrics should be scraped |
 | serviceMonitor.scrapeTimeout | string | `"30s"` | Timeout after which the scrape is ended |

--- a/helm/charts/hydra-maester/templates/service-monitor.yaml
+++ b/helm/charts/hydra-maester/templates/service-monitor.yaml
@@ -21,6 +21,12 @@ spec:
       scheme: {{ .Values.serviceMonitor.scheme }}
       interval: {{ .Values.serviceMonitor.scrapeInterval }}
       scrapeTimeout: {{ .Values.serviceMonitor.scrapeTimeout }}
+      {{- if .Values.serviceMonitor.metricRelabelings }}
+      metricRelabelings: {{- toYaml .Values.serviceMonitor.metricRelabelings | nindent 6 }}
+      {{- end }}
+      {{- if .Values.serviceMonitor.relabelings }}
+      relabelings: {{- toYaml .Values.serviceMonitor.relabelings | nindent 6 }}
+      {{- end }}
       {{- with .Values.serviceMonitor.tlsConfig }}
       tlsConfig:
         {{- toYaml . | nindent 6 }}

--- a/helm/charts/hydra-maester/values.yaml
+++ b/helm/charts/hydra-maester/values.yaml
@@ -187,6 +187,12 @@ serviceMonitor:
   scrapeInterval: 60s
   # -- Timeout after which the scrape is ended
   scrapeTimeout: 30s
+  # -- Relabeling is a powerful tool to dynamically rewrite the label set of a target before it gets scraped.
+  # Reference: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
+  relabelings: []
+  # -- Metric relabeling is applied to samples as the last step before ingestion.
+  # Reference: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#metric_relabel_configs
+  metricRelabelings: []
   # -- Provide additional labels to the ServiceMonitor resource metadata
   labels: {}
   # -- TLS configuration to use when scraping the endpoint

--- a/helm/charts/hydra/README.md
+++ b/helm/charts/hydra/README.md
@@ -202,6 +202,8 @@ A Helm chart for deploying ORY Hydra in Kubernetes
 | service.public.type | string | `"ClusterIP"` | The service type |
 | serviceMonitor.enabled | bool | `false` | switch to true to enable creating the ServiceMonitor |
 | serviceMonitor.labels | object | `{}` | Provide additionnal labels to the ServiceMonitor ressource metadata |
+| serviceMonitor.metricRelabelings | list | `[]` | Metric relabeling is applied to samples as the last step before ingestion. Reference: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#metric_relabel_configs |
+| serviceMonitor.relabelings | list | `[]` | Relabeling is a powerful tool to dynamically rewrite the label set of a target before it gets scraped. Reference: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config |
 | serviceMonitor.scheme | string | `"http"` | HTTP scheme to use for scraping. |
 | serviceMonitor.scrapeInterval | string | `"60s"` | Interval at which metrics should be scraped |
 | serviceMonitor.scrapeTimeout | string | `"30s"` | Timeout after which the scrape is ended |

--- a/helm/charts/hydra/templates/service-admin.yaml
+++ b/helm/charts/hydra/templates/service-admin.yaml
@@ -58,6 +58,12 @@ spec:
     scheme: {{ .Values.serviceMonitor.scheme }}
     interval: {{ .Values.serviceMonitor.scrapeInterval }}
     scrapeTimeout: {{ .Values.serviceMonitor.scrapeTimeout }}
+    {{- if .Values.serviceMonitor.metricRelabelings }}
+    metricRelabelings: {{- toYaml .Values.serviceMonitor.metricRelabelings | nindent 6 }}
+    {{- end }}
+    {{- if .Values.serviceMonitor.relabelings }}
+    relabelings: {{- toYaml .Values.serviceMonitor.relabelings | nindent 6 }}
+    {{- end }}
     {{- with .Values.serviceMonitor.tlsConfig }}
     tlsConfig:
       {{- toYaml . | nindent 6 }}

--- a/helm/charts/hydra/values.yaml
+++ b/helm/charts/hydra/values.yaml
@@ -690,6 +690,12 @@ serviceMonitor:
   scrapeInterval: 60s
   # -- Timeout after which the scrape is ended
   scrapeTimeout: 30s
+  # -- Relabeling is a powerful tool to dynamically rewrite the label set of a target before it gets scraped.
+  # Reference: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
+  relabelings: []
+  # -- Metric relabeling is applied to samples as the last step before ingestion.
+  # Reference: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#metric_relabel_configs
+  metricRelabelings: []
   # -- Provide additionnal labels to the ServiceMonitor ressource metadata
   labels: {}
   # -- TLS configuration to use when scraping the endpoint

--- a/helm/charts/keto/README.md
+++ b/helm/charts/keto/README.md
@@ -184,6 +184,8 @@ Access Control Policies as a Server
 | serviceAccount.create | bool | `true` | Specifies whether a service account should be created |
 | serviceAccount.name | string | `""` | The name of the service account to use. If not set and create is true, a name is generated using the fullname template |
 | serviceMonitor.labels | object | `{}` | Provide additionnal labels to the ServiceMonitor ressource metadata |
+| serviceMonitor.metricRelabelings | list | `[]` | Metric relabeling is applied to samples as the last step before ingestion. Reference: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#metric_relabel_configs |
+| serviceMonitor.relabelings | list | `[]` | Relabeling is a powerful tool to dynamically rewrite the label set of a target before it gets scraped. Reference: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config |
 | serviceMonitor.scheme | string | `"http"` | HTTP scheme to use for scraping. |
 | serviceMonitor.scrapeInterval | string | `"60s"` | Interval at which metrics should be scraped |
 | serviceMonitor.scrapeTimeout | string | `"30s"` | Timeout after which the scrape is ended |

--- a/helm/charts/keto/templates/servicemonitor-metrics.yaml
+++ b/helm/charts/keto/templates/servicemonitor-metrics.yaml
@@ -24,6 +24,12 @@ spec:
     scheme: {{ .Values.serviceMonitor.scheme }}
     interval: {{ .Values.serviceMonitor.scrapeInterval }}
     scrapeTimeout: {{ .Values.serviceMonitor.scrapeTimeout }}
+    {{- if .Values.serviceMonitor.metricRelabelings }}
+    metricRelabelings: {{- toYaml .Values.serviceMonitor.metricRelabelings | nindent 6 }}
+    {{- end }}
+    {{- if .Values.serviceMonitor.relabelings }}
+    relabelings: {{- toYaml .Values.serviceMonitor.relabelings | nindent 6 }}
+    {{- end }}
     {{- with .Values.serviceMonitor.tlsConfig }}
     tlsConfig:
       {{- toYaml . | nindent 6 }}

--- a/helm/charts/keto/values.yaml
+++ b/helm/charts/keto/values.yaml
@@ -481,6 +481,12 @@ serviceMonitor:
   scrapeInterval: 60s
   # -- Timeout after which the scrape is ended
   scrapeTimeout: 30s
+  # -- Relabeling is a powerful tool to dynamically rewrite the label set of a target before it gets scraped.
+  # Reference: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
+  relabelings: []
+  # -- Metric relabeling is applied to samples as the last step before ingestion.
+  # Reference: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#metric_relabel_configs
+  metricRelabelings: []
   # -- Provide additionnal labels to the ServiceMonitor ressource metadata
   labels: {}
   # -- TLS configuration to use when scraping the endpoint

--- a/helm/charts/kratos/README.md
+++ b/helm/charts/kratos/README.md
@@ -198,6 +198,8 @@ A ORY Kratos Helm chart for Kubernetes
 | service.public.type | string | `"ClusterIP"` |  |
 | serviceMonitor.enabled | bool | `false` | switch to true to enable creating the ServiceMonitor |
 | serviceMonitor.labels | object | `{}` | Provide additional labels to the ServiceMonitor ressource metadata |
+| serviceMonitor.metricRelabelings | list | `[]` | Metric relabeling is applied to samples as the last step before ingestion. Reference: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#metric_relabel_configs |
+| serviceMonitor.relabelings | list | `[]` | Relabeling is a powerful tool to dynamically rewrite the label set of a target before it gets scraped. Reference: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config |
 | serviceMonitor.scheme | string | `"http"` | HTTP scheme to use for scraping. |
 | serviceMonitor.scrapeInterval | string | `"60s"` | Interval at which metrics should be scraped |
 | serviceMonitor.scrapeTimeout | string | `"30s"` | Timeout after which the scrape is ended |

--- a/helm/charts/kratos/templates/service-admin.yaml
+++ b/helm/charts/kratos/templates/service-admin.yaml
@@ -63,6 +63,12 @@ spec:
     scheme: {{ .Values.serviceMonitor.scheme }}
     interval: {{ .Values.serviceMonitor.scrapeInterval }}
     scrapeTimeout: {{ .Values.serviceMonitor.scrapeTimeout }}
+    {{- if .Values.serviceMonitor.metricRelabelings }}
+    metricRelabelings: {{- toYaml .Values.serviceMonitor.metricRelabelings | nindent 6 }}
+    {{- end }}
+    {{- if .Values.serviceMonitor.relabelings }}
+    relabelings: {{- toYaml .Values.serviceMonitor.relabelings | nindent 6 }}
+    {{- end }}
     {{- with .Values.serviceMonitor.tlsConfig }}
     tlsConfig:
       {{- toYaml . | nindent 6 }}

--- a/helm/charts/kratos/templates/svc-statefulset.yaml
+++ b/helm/charts/kratos/templates/svc-statefulset.yaml
@@ -64,6 +64,12 @@ spec:
     scheme: {{ .Values.serviceMonitor.scheme }}
     interval: {{ .Values.serviceMonitor.scrapeInterval }}
     scrapeTimeout: {{ .Values.serviceMonitor.scrapeTimeout }}
+    {{- if .Values.serviceMonitor.metricRelabelings }}
+    metricRelabelings: {{- toYaml .Values.serviceMonitor.metricRelabelings | nindent 6 }}
+    {{- end }}
+    {{- if .Values.serviceMonitor.relabelings }}
+    relabelings: {{- toYaml .Values.serviceMonitor.relabelings | nindent 6 }}
+    {{- end }}
     {{- with .Values.serviceMonitor.tlsConfig }}
     tlsConfig:
       {{- toYaml . | nindent 6 }}

--- a/helm/charts/kratos/values.yaml
+++ b/helm/charts/kratos/values.yaml
@@ -783,6 +783,12 @@ serviceMonitor:
   scrapeInterval: 60s
   # -- Timeout after which the scrape is ended
   scrapeTimeout: 30s
+  # -- Relabeling is a powerful tool to dynamically rewrite the label set of a target before it gets scraped.
+  # Reference: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
+  relabelings: []
+  # -- Metric relabeling is applied to samples as the last step before ingestion.
+  # Reference: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#metric_relabel_configs
+  metricRelabelings: []
   # -- Provide additional labels to the ServiceMonitor ressource metadata
   labels: {}
   # -- TLS configuration to use when scraping the endpoint


### PR DESCRIPTION
# Add relabeling and metricRelabeling for all helm charts

This pull request updates all Helm charts to support feat-relabeling and metric relabeling.
It introduces new configuration options that allow users to customize relabeling rules for Prometheus metrics
across all charts in a consistent way.

Fix: #805

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md) and signed the CLA.
- [x] I have referenced an issue containing the design document if my change introduces a new feature.
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security vulnerability. 
      If this pull request addresses a security vulnerability, 
      I confirm that I got approval (please contact [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push the changes.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added the necessary documentation within the code base (if appropriate).

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
