### PR TITLE
feat: make kratos-selfservice-ui-node probes configurable

### DIFF
--- a/helm/charts/kratos-selfservice-ui-node/Chart.yaml
+++ b/helm/charts/kratos-selfservice-ui-node/Chart.yaml
@@ -3,5 +3,5 @@ apiVersion: v2
 appVersion: "v0.13.0-4"
 description: A Helm chart for ORY Kratos's example ui for Kubernetes
 name: kratos-selfservice-ui-node
-version: 0.61.1
+version: 0.61.2
 type: application

--- a/helm/charts/kratos-selfservice-ui-node/README.md
+++ b/helm/charts/kratos-selfservice-ui-node/README.md
@@ -1,6 +1,6 @@
 # kratos-selfservice-ui-node
 
-![Version: 0.61.1](https://img.shields.io/badge/Version-0.61.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.13.0-4](https://img.shields.io/badge/AppVersion-v0.13.0--4-informational?style=flat-square)
+![Version: 0.61.2](https://img.shields.io/badge/Version-0.61.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.13.0-4](https://img.shields.io/badge/AppVersion-v0.13.0--4-informational?style=flat-square)
 
 A Helm chart for ORY Kratos's example ui for Kubernetes
 
@@ -14,6 +14,8 @@ A Helm chart for ORY Kratos's example ui for Kubernetes
 | config.secrets | object | `{}` |  |
 | deployment.annotations | object | `{}` |  |
 | deployment.automountServiceAccountToken | bool | `false` |  |
+| deployment.customLivenessProbe | object | `{}` | Provide a full override of the liveness probe. Useful when the UI is serving HTTPS (e.g. via TLS_CERT_PATH / TLS_KEY_PATH) and the default HTTP probe needs to be replaced with an HTTPS one, or when a custom tcpSocket/exec probe is required. |
+| deployment.customReadinessProbe | object | `{}` | Provide a full override of the readiness probe. See customLivenessProbe for when to use this. |
 | deployment.dnsConfig | object | `{}` | Configure pod dnsConfig. |
 | deployment.extraEnv | list | `[]` | Array of extra envs to be passed to the deployment. Kubernetes format is expected - name: FOO   value: BAR |
 | deployment.extraVolumeMounts | list | `[]` |  |

--- a/helm/charts/kratos-selfservice-ui-node/templates/deployment.yaml
+++ b/helm/charts/kratos-selfservice-ui-node/templates/deployment.yaml
@@ -85,14 +85,24 @@ spec:
             - name: http
               containerPort: 3000
               protocol: TCP
+          {{- if .Values.deployment.customLivenessProbe }}
+          livenessProbe:
+            {{- toYaml .Values.deployment.customLivenessProbe | nindent 12 }}
+          {{- else }}
           livenessProbe:
             httpGet:
               path: {{ .Values.basePath }}/health/alive
               port: http
+          {{- end }}
+          {{- if .Values.deployment.customReadinessProbe }}
+          readinessProbe:
+            {{- toYaml .Values.deployment.customReadinessProbe | nindent 12 }}
+          {{- else }}
           readinessProbe:
             httpGet:
               path: {{ .Values.basePath }}/health/ready
               port: http
+          {{- end }}
           resources:
             {{- toYaml .Values.deployment.resources | nindent 12 }}
           {{- if .Values.securityContext }}

--- a/helm/charts/kratos-selfservice-ui-node/values.yaml
+++ b/helm/charts/kratos-selfservice-ui-node/values.yaml
@@ -186,6 +186,30 @@ deployment:
   automountServiceAccountToken: false
   terminationGracePeriodSeconds: 60
 
+  # -- Provide a full override of the liveness probe. Useful when the UI is
+  # serving HTTPS (e.g. via TLS_CERT_PATH / TLS_KEY_PATH) and the default
+  # HTTP probe needs to be replaced with an HTTPS one, or when a custom
+  # tcpSocket/exec probe is required.
+  customLivenessProbe: {}
+  # customLivenessProbe:
+  #   httpGet:
+  #     path: /health/alive
+  #     port: http
+  #     scheme: HTTPS
+  #   initialDelaySeconds: 5
+  #   periodSeconds: 10
+
+  # -- Provide a full override of the readiness probe. See customLivenessProbe
+  # for when to use this.
+  customReadinessProbe: {}
+  # customReadinessProbe:
+  #   httpGet:
+  #     path: /health/ready
+  #     port: http
+  #     scheme: HTTPS
+  #   initialDelaySeconds: 3
+  #   periodSeconds: 5
+
 affinity: {}
 
 # -- Set this to ORY Kratos's Admin URL


### PR DESCRIPTION
## Description

The UI supports HTTPS via `TLS_CERT_PATH` / `TLS_KEY_PATH`, but the chart's probes are hardcoded HTTP, so the pod crash-loops once TLS is turned on.

This adds `deployment.customLivenessProbe` and `deployment.customReadinessProbe`, same pattern as the kratos chart (`deployment-kratos.yaml`). Both default to `{}`, so existing deployments are unchanged.

Verified with `helm lint` and `helm template` in default and override modes.

## Checklist

- [x] I have read the security policy.
- [x] I confirm that this pull request does not address a security vulnerability.
- [x] I have added the necessary documentation within the code base (values.yaml + regenerated README via helm-docs).
- [ ] I have added tests that prove my fix is effective or that my feature works.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Custom Kubernetes health probe configurations (liveness and readiness checks) are now supported, enabling advanced deployment scenarios including HTTPS-based health monitoring and customized probe timing, while maintaining backward compatibility with default HTTP probes.

* **Chores**
  * Helm chart version updated to 0.61.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->