### PR TITLE
fix: set Deployment namespace to .Release.Namespace

### DIFF
--- a/helm/charts/hydra-maester/templates/deployment.yaml
+++ b/helm/charts/hydra-maester/templates/deployment.yaml
@@ -6,6 +6,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "hydra-maester.fullname" . }}
+  namespace:  {{ .Release.Namespace }}
   labels:
     {{- include "hydra-maester.labels" . | nindent 4 }}
     {{- with .Values.deployment.extraLabels }}


### PR DESCRIPTION
solves 873

## Summary

When installing the Hydra chart into a non-default namespace, the
`hydra-hydra-maester` Deployment was still created in the `default`
namespace instead of the release namespace.

The Deployment template in
`helm/charts/hydra-maester/templates/deployment.yaml` did not set
`metadata.namespace`, so Helm fell back to the active kubeconfig
namespace (`default`) rather than `.Release.Namespace`. This patch adds:

```yaml
namespace: {{ .Release.Namespace }}
```

to the Deployment metadata so the resource is consistently created in
the release namespace.

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md) and signed the CLA.
- [ x ] I have referenced an issue containing the design document if my change introduces a new feature.
- [ ] I have read the [security policy](../security/policy).
- [ x ] I confirm that this pull request does not address a security vulnerability. 
      If this pull request addresses a security vulnerability, 
      I confirm that I got approval (please contact [security@ory.com](mailto:security@ory.com)) from the maintainers to push the changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added the necessary documentation within the code base (if appropriate).




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Deployment manifests now include the release namespace, ensuring the application is deployed into the correct Helm release namespace.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ory/k8s/pull/874?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->