### PR TITLE
feat: add per-job extra volumes to hydra migration job

### DIFF
--- a/hacks/values/hydra/default.yaml
+++ b/hacks/values/hydra/default.yaml
@@ -154,6 +154,12 @@ job:
       image: "alpine:latest"
       command: ["/bin/sh"]
       args: ["-c", "sleep 10"]
+  extraVolumes:
+    - name: job-extra
+      emptyDir: {}
+  extraVolumeMounts:
+    - name: job-extra
+      mountPath: /job-extra
   shareProcessNamespace: true
   podMetadata:
     labels:

--- a/helm/charts/hydra/README.md
+++ b/helm/charts/hydra/README.md
@@ -161,6 +161,8 @@ A Helm chart for deploying ORY Hydra in Kubernetes
 | job.extraContainers | string | `""` | If you want to add extra sidecar containers. |
 | job.extraEnv | list | `[]` | Array of extra envs to be passed to the job. This takes precedence over deployment variables. Kubernetes format is expected. Value is processed with Helm `tpl` - name: FOO   value: BAR |
 | job.extraInitContainers | string | `""` | If you want to add extra init containers. extraInitContainers: |  - name: ...    image: ... |
+| job.extraVolumeMounts | list | `[]` | Array of extra volume mounts to be mounted on the job. This takes precedence over `deployment.extraVolumeMounts` when set, otherwise the deployment's volume mounts are used. |
+| job.extraVolumes | list | `[]` | Array of extra volumes to be mounted on the job. This takes precedence over `deployment.extraVolumes` when set, otherwise the deployment's volumes are used. |
 | job.labels | object | `{}` | Set custom deployment level labels |
 | job.lifecycle | string | `""` | If you want to add lifecycle hooks. |
 | job.nodeSelector | object | `{}` | Node labels for pod assignment. |

--- a/helm/charts/hydra/templates/job-migration.yaml
+++ b/helm/charts/hydra/templates/job-migration.yaml
@@ -2,6 +2,8 @@
 {{- if and  ( .Values.hydra.automigration.enabled ) ( eq .Values.hydra.automigration.type "job" ) }}
 {{- $nodeSelector := ternary .Values.job.nodeSelector .Values.deployment.nodeSelector (not (empty .Values.job.nodeSelector )) -}}
 {{- $migrationExtraEnv := ternary .Values.job.extraEnv .Values.deployment.extraEnv (not (empty .Values.job.extraEnv )) -}}
+{{- $migrationExtraVolumes := ternary .Values.job.extraVolumes .Values.deployment.extraVolumes (not (empty .Values.job.extraVolumes )) -}}
+{{- $migrationExtraVolumeMounts := ternary .Values.job.extraVolumeMounts .Values.deployment.extraVolumeMounts (not (empty .Values.job.extraVolumeMounts )) -}}
 {{- $resources := ternary .Values.job.resources .Values.hydra.automigration.resources (not (empty .Values.job.resources)) -}}
 
 ---
@@ -96,9 +98,9 @@ spec:
           - name: {{ include "hydra.name" . }}-config-volume
             mountPath: /etc/config
             readOnly: true
-          {{- if .Values.deployment.extraVolumeMounts }}
-            {{- toYaml .Values.deployment.extraVolumeMounts | nindent 10 }}
-         {{- end }}
+          {{- with $migrationExtraVolumeMounts }}
+            {{- toYaml . | nindent 10 }}
+          {{- end }}
       {{- if .Values.job.extraContainers }}
         {{- tpl .Values.job.extraContainers . | nindent 6 }}
       {{- end }}
@@ -116,8 +118,8 @@ spec:
         - name: {{ include "hydra.name" . }}-config-volume
           configMap:
             name: {{ include "hydra.fullname" . }}-migrate
-        {{- if .Values.deployment.extraVolumes }}
-          {{- toYaml .Values.deployment.extraVolumes | nindent 8 }}
+        {{- with $migrationExtraVolumes }}
+          {{- toYaml . | nindent 8 }}
         {{- end }}
       {{- with $nodeSelector }}
       nodeSelector:

--- a/helm/charts/hydra/values.yaml
+++ b/helm/charts/hydra/values.yaml
@@ -446,6 +446,20 @@ job:
   #   value: BAR
   extraEnv: []
 
+  # -- Array of extra volumes to be mounted on the job. This takes precedence over `deployment.extraVolumes` when set,
+  # otherwise the deployment's volumes are used.
+  extraVolumes: []
+  # - name: my-volume
+  #   secret:
+  #     secretName: my-secret
+
+  # -- Array of extra volume mounts to be mounted on the job. This takes precedence over `deployment.extraVolumeMounts`
+  # when set, otherwise the deployment's volume mounts are used.
+  extraVolumeMounts: []
+  # - name: my-volume
+  #   mountPath: /etc/secrets/my-secret
+  #   readOnly: true
+
   # -- Specify pod metadata, this metadata is added directly to the pod, and not higher objects
   podMetadata:
     # -- Extra pod level labels


### PR DESCRIPTION
The hydra migration `Job` currently has no way to mount volumes independently of the long-running `deployment`. The `volumes` / `volumeMounts` blocks in `templates/job-migration.yaml` are hardcoded to `.Values.deployment.extraVolumes` and `.Values.deployment.extraVolumeMounts`, so the only way to attach a volume to the short-lived migration pod is to also attach it to the server deployment.

This is inconsistent with the rest of that same template, where `job.nodeSelector`, `job.extraEnv`, and `job.resources` already override their `deployment.*` / `automigration.*` counterparts via a `ternary` fallback. This PR closes that gap by adding `job.extraVolumes` and `job.extraVolumeMounts`, following the identical fallback pattern:

```yaml
job:
  extraVolumes:
    - name: my-volume
      secret:
        secretName: my-secret
  extraVolumeMounts:
    - name: my-volume
      mountPath: /etc/secrets/my-secret
      readOnly: true
```

**Backward compatible:** both default to `[]`. When unset, the job continues to fall back to `deployment.extraVolumes` / `deployment.extraVolumeMounts`, so existing releases render byte-for-byte identically. The change also converts the two blocks from `if` to `with` and fixes a mis-indented `{{- end }}` in the existing `volumeMounts` block.

## Related Issue or Design Document

No linked issue. This is a small consistency enhancement rather than a new feature: it extends the pre-existing `job.* → deployment.*` override pattern in `templates/job-migration.yaml` (already present for `nodeSelector`, `extraEnv`, and `resources`) to volumes. Happy to open a discussion first if maintainers prefer.

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md) and signed the CLA.
- [ ] I have referenced an issue containing the design document if my change introduces a new feature. <!-- N/A: extends an existing pattern, not a new feature -->
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security vulnerability.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added the necessary documentation within the code base (if appropriate).

## Further comments

**Alternative considered:** keeping the volumes coupled to `deployment.extraVolumes`. Rejected because it forces unrelated volumes (e.g. a migration-only credential mount) onto the always-running server pod, and because every sibling setting in the same template already supports a per-job override — this just makes volumes consistent.

The `hacks/values/hydra/default.yaml` change adds an `emptyDir`-backed `job.extraVolumes` + `job.extraVolumeMounts` so the existing render/kubeconform CI exercises the new code path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added job-level `extraVolumes` and `extraVolumeMounts` configuration options for Hydra Helm chart. These settings take precedence over deployment-level volume configurations when specified.

* **Documentation**
  * Updated Helm chart documentation to reflect new job-specific volume configuration options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->