### PR TITLE
fix: add namespace to remaining poddisruptionbudget helm templates

### DIFF
--- a/helm/charts/hydra-maester/templates/pdb.yaml
+++ b/helm/charts/hydra-maester/templates/pdb.yaml
@@ -4,6 +4,9 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "hydra-maester.fullname" . }}
+  {{- if .Release.Namespace }}
+  namespace: {{ .Release.Namespace }}
+  {{- end }}
 spec:
   selector:
     matchLabels:

--- a/helm/charts/kratos/templates/pdb.yaml
+++ b/helm/charts/kratos/templates/pdb.yaml
@@ -4,6 +4,9 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "kratos.fullname" . }}
+  {{- if .Release.Namespace }}
+  namespace: {{ .Release.Namespace }}
+  {{- end }}
 spec:
   selector:
     matchLabels:

--- a/helm/charts/oathkeeper-maester/templates/pdb.yaml
+++ b/helm/charts/oathkeeper-maester/templates/pdb.yaml
@@ -4,6 +4,9 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "oathkeeper-maester.fullname" . }}
+  {{- if .Release.Namespace }}
+  namespace: {{ .Release.Namespace }}
+  {{- end }}
 spec:
   selector:
     matchLabels:


### PR DESCRIPTION
The PodDisruptionBudget templates for kratos, hydra-maester, and
oathkeeper-maester don't set `metadata.namespace`, so the PDB doesn't
inherit the release namespace. This completes the same fix already
merged for hydra (#885) and in progress for oathkeeper (#883); keto
already has it.

Same guard as #885:

```
  {{- if .Release.Namespace }}
  namespace: {{ .Release.Namespace }}
  {{- end }}
```

Validation:
- `helm template` on all three charts with `pdb.enabled=true` renders
  `namespace: <release-namespace>` on the PDB.
- default render is unchanged; the only delta vs master is the added
  namespace line.

related: #882, #884

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * PodDisruptionBudget resources now include the release namespace when one is provided, improving chart rendering consistency across deployments.
  * Applied the same namespace handling across all affected charts to reduce surprises during installation or upgrade.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->