### PR TITLE
feat: add Gateway API HTTPRoute support to Kratos, Hydra, Keto, and Oathkeeper

### DIFF
--- a/helm/charts/hydra/README.md
+++ b/helm/charts/hydra/README.md
@@ -114,6 +114,30 @@ A Helm chart for deploying ORY Hydra in Kubernetes
 | global.podMetadata | object | `{"annotations":{},"labels":{}}` | Specify pod metadata, this metadata is added directly to the pod, and not higher objects |
 | global.podMetadata.annotations | object | `{}` | Extra pod level annotations |
 | global.podMetadata.labels | object | `{}` | Extra pod level labels |
+| httproute.admin.annotations | object | `{}` | Provide custom annotations for the HTTPRoute |
+| httproute.admin.apiVersion | string | `""` | Override the HTTPRoute API version (defaults to gateway.networking.k8s.io/v1) |
+| httproute.admin.enabled | bool | `false` | En/disable the HTTPRoute resource for admin service |
+| httproute.admin.filters | list | `[]` | Filters for the default rule if rules is empty |
+| httproute.admin.hostnames | list | `[]` | Hostnames matching the rule |
+| httproute.admin.labels | object | `{}` | Provide custom labels for the HTTPRoute |
+| httproute.admin.matches | list | `[{"path":{"type":"PathPrefix","value":"/"}}]` | Path matches for the default rule if rules is empty |
+| httproute.admin.nameOverride | string | `""` | Override the HTTPRoute metadata name |
+| httproute.admin.parentRefs | list | `[]` | References to parent Gateway resources |
+| httproute.admin.rules | list | `[]` | Custom routing rules. If not provided, a default rule routing to the admin service will be used |
+| httproute.admin.servicePort | string | `nil` | Override the service port in the default backend rule |
+| httproute.admin.weight | string | `nil` | Weight for the default backend rule |
+| httproute.public.annotations | object | `{}` | Provide custom annotations for the HTTPRoute |
+| httproute.public.apiVersion | string | `""` | Override the HTTPRoute API version (defaults to gateway.networking.k8s.io/v1) |
+| httproute.public.enabled | bool | `false` | En/disable the HTTPRoute resource for public service |
+| httproute.public.filters | list | `[]` | Filters for the default rule if rules is empty |
+| httproute.public.hostnames | list | `[]` | Hostnames matching the rule |
+| httproute.public.labels | object | `{}` | Provide custom labels for the HTTPRoute |
+| httproute.public.matches | list | `[{"path":{"type":"PathPrefix","value":"/"}}]` | Path matches for the default rule if rules is empty |
+| httproute.public.nameOverride | string | `""` | Override the HTTPRoute metadata name |
+| httproute.public.parentRefs | list | `[]` | References to parent Gateway resources |
+| httproute.public.rules | list | `[]` | Custom routing rules. If not provided, a default rule routing to the public service will be used |
+| httproute.public.servicePort | string | `nil` | Override the service port in the default backend rule |
+| httproute.public.weight | string | `nil` | Weight for the default backend rule |
 | hydra-maester.adminService.name | string | `""` | The service name value may need to be set if you use `fullnameOverride` for the parent chart |
 | hydra.automigration.customArgs | list | `[]` | Ability to override arguments of the entrypoint. Can be used in-depended of customCommand eg: - sleep 5;   - kratos |
 | hydra.automigration.customCommand | list | `[]` | Ability to override the entrypoint of the automigration container (e.g. to source dynamic secrets or export environment dynamic variables) |

--- a/helm/charts/hydra/README.md
+++ b/helm/charts/hydra/README.md
@@ -117,7 +117,7 @@ A Helm chart for deploying ORY Hydra in Kubernetes
 | global.podMetadata.labels | object | `{}` | Extra pod level labels |
 | httproute.admin.annotations | object | `{}` | Provide custom annotations for the HTTPRoute |
 | httproute.admin.apiVersion | string | `""` | Override the HTTPRoute API version (defaults to gateway.networking.k8s.io/v1) |
-| httproute.admin.enabled | bool | `false` | En/disable the HTTPRoute resource for admin service |
+| httproute.admin.enabled | bool | `false` | Enable/disable the HTTPRoute resource for admin service |
 | httproute.admin.filters | list | `[]` | Filters for the default rule if rules is empty |
 | httproute.admin.hostnames | list | `[]` | Hostnames matching the rule |
 | httproute.admin.labels | object | `{}` | Provide custom labels for the HTTPRoute |
@@ -129,7 +129,7 @@ A Helm chart for deploying ORY Hydra in Kubernetes
 | httproute.admin.weight | string | `nil` | Weight for the default backend rule |
 | httproute.public.annotations | object | `{}` | Provide custom annotations for the HTTPRoute |
 | httproute.public.apiVersion | string | `""` | Override the HTTPRoute API version (defaults to gateway.networking.k8s.io/v1) |
-| httproute.public.enabled | bool | `false` | En/disable the HTTPRoute resource for public service |
+| httproute.public.enabled | bool | `false` | Enable/disable the HTTPRoute resource for public service |
 | httproute.public.filters | list | `[]` | Filters for the default rule if rules is empty |
 | httproute.public.hostnames | list | `[]` | Hostnames matching the rule |
 | httproute.public.labels | object | `{}` | Provide custom labels for the HTTPRoute |

--- a/helm/charts/hydra/README.md
+++ b/helm/charts/hydra/README.md
@@ -108,6 +108,7 @@ A Helm chart for deploying ORY Hydra in Kubernetes
 | deployment.terminationGracePeriodSeconds | int | `60` |  |
 | deployment.tolerations | list | `[]` | Configure node tolerations. |
 | deployment.topologySpreadConstraints | list | `[]` | Configure pod topologySpreadConstraints. |
+| extraDeploy | list | `[]` | Array of extra resources to deploy with the chart |
 | fullnameOverride | string | `""` | Full chart name override |
 | global | object | `{"imageRegistry":null,"podMetadata":{"annotations":{},"labels":{}}}` | Global setting, passed down to all pods |
 | global.imageRegistry | string | `nil` | Overrides the Docker registry globally for all images |

--- a/helm/charts/hydra/templates/extra-deploy.yaml
+++ b/helm/charts/hydra/templates/extra-deploy.yaml
@@ -1,0 +1,4 @@
+{{- range .Values.extraDeploy }}
+---
+{{ tpl (toYaml .) $ }}
+{{- end }}

--- a/helm/charts/hydra/templates/httproute-admin.yaml
+++ b/helm/charts/hydra/templates/httproute-admin.yaml
@@ -34,7 +34,7 @@ spec:
     - backendRefs:
         - name: {{ $fullName }}-admin
           port: {{ default $.Values.service.admin.port .Values.httproute.admin.servicePort }}
-          {{- if .Values.httproute.admin.weight }}
+          {{- if not (kindIs "invalid" .Values.httproute.admin.weight) }}
           weight: {{ .Values.httproute.admin.weight }}
           {{- end }}
       {{- if .Values.httproute.admin.matches }}

--- a/helm/charts/hydra/templates/httproute-admin.yaml
+++ b/helm/charts/hydra/templates/httproute-admin.yaml
@@ -1,0 +1,54 @@
+{{- if .Values.httproute.admin.enabled -}}
+{{- $fullName := include "hydra.fullname" . -}}
+apiVersion: {{ default "gateway.networking.k8s.io/v1" .Values.httproute.admin.apiVersion }}
+kind: HTTPRoute
+metadata:
+  name: {{ default (printf "%s-admin" $fullName) .Values.httproute.admin.nameOverride }}
+  {{- if .Release.Namespace }}
+  namespace: {{ .Release.Namespace }}
+  {{- end }}
+  labels:
+    {{- include "hydra.labels" . | nindent 4 }}
+    {{- with .Values.httproute.admin.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.httproute.admin.annotations }}
+  annotations:
+    {{- tpl (toYaml .) $ | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.httproute.admin.parentRefs }}
+  parentRefs:
+    {{- tpl (toYaml .) $ | nindent 4 }}
+  {{- end }}
+  {{- with .Values.httproute.admin.hostnames }}
+  hostnames:
+    {{- range . }}
+    - {{ tpl . $ | quote }}
+    {{- end }}
+  {{- end }}
+  rules:
+  {{- if .Values.httproute.admin.rules }}
+    {{- tpl (toYaml .Values.httproute.admin.rules) $ | nindent 4 }}
+  {{- else }}
+    - backendRefs:
+        - name: {{ $fullName }}-admin
+          port: {{ default $.Values.service.admin.port .Values.httproute.admin.servicePort }}
+          {{- if .Values.httproute.admin.weight }}
+          weight: {{ .Values.httproute.admin.weight }}
+          {{- end }}
+      {{- if .Values.httproute.admin.matches }}
+      matches:
+        {{- tpl (toYaml .Values.httproute.admin.matches) $ | nindent 8 }}
+      {{- else }}
+      matches:
+        - path:
+            type: PathPrefix
+            value: /
+      {{- end }}
+      {{- with .Values.httproute.admin.filters }}
+      filters:
+        {{- tpl (toYaml .) $ | nindent 8 }}
+      {{- end }}
+  {{- end }}
+{{- end }}

--- a/helm/charts/hydra/templates/httproute-public.yaml
+++ b/helm/charts/hydra/templates/httproute-public.yaml
@@ -34,7 +34,7 @@ spec:
     - backendRefs:
         - name: {{ $fullName }}-public
           port: {{ default $.Values.service.public.port .Values.httproute.public.servicePort }}
-          {{- if .Values.httproute.public.weight }}
+          {{- if not (kindIs "invalid" .Values.httproute.public.weight) }}
           weight: {{ .Values.httproute.public.weight }}
           {{- end }}
       {{- if .Values.httproute.public.matches }}

--- a/helm/charts/hydra/templates/httproute-public.yaml
+++ b/helm/charts/hydra/templates/httproute-public.yaml
@@ -1,0 +1,54 @@
+{{- if .Values.httproute.public.enabled -}}
+{{- $fullName := include "hydra.fullname" . -}}
+apiVersion: {{ default "gateway.networking.k8s.io/v1" .Values.httproute.public.apiVersion }}
+kind: HTTPRoute
+metadata:
+  name: {{ default (printf "%s-public" $fullName) .Values.httproute.public.nameOverride }}
+  {{- if .Release.Namespace }}
+  namespace: {{ .Release.Namespace }}
+  {{- end }}
+  labels:
+    {{- include "hydra.labels" . | nindent 4 }}
+    {{- with .Values.httproute.public.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.httproute.public.annotations }}
+  annotations:
+    {{- tpl (toYaml .) $ | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.httproute.public.parentRefs }}
+  parentRefs:
+    {{- tpl (toYaml .) $ | nindent 4 }}
+  {{- end }}
+  {{- with .Values.httproute.public.hostnames }}
+  hostnames:
+    {{- range . }}
+    - {{ tpl . $ | quote }}
+    {{- end }}
+  {{- end }}
+  rules:
+  {{- if .Values.httproute.public.rules }}
+    {{- tpl (toYaml .Values.httproute.public.rules) $ | nindent 4 }}
+  {{- else }}
+    - backendRefs:
+        - name: {{ $fullName }}-public
+          port: {{ default $.Values.service.public.port .Values.httproute.public.servicePort }}
+          {{- if .Values.httproute.public.weight }}
+          weight: {{ .Values.httproute.public.weight }}
+          {{- end }}
+      {{- if .Values.httproute.public.matches }}
+      matches:
+        {{- tpl (toYaml .Values.httproute.public.matches) $ | nindent 8 }}
+      {{- else }}
+      matches:
+        - path:
+            type: PathPrefix
+            value: /
+      {{- end }}
+      {{- with .Values.httproute.public.filters }}
+      filters:
+        {{- tpl (toYaml .) $ | nindent 8 }}
+      {{- end }}
+  {{- end }}
+{{- end }}

--- a/helm/charts/hydra/values.yaml
+++ b/helm/charts/hydra/values.yaml
@@ -147,6 +147,73 @@ ingress:
 #        - api.hydra.local
 #      - secretName: hydra-api-example-tls
 
+## -- HTTPRoute definition (Kubernetes Gateway API)
+httproute:
+  admin:
+    # -- En/disable the HTTPRoute resource for admin service
+    enabled: false
+    # -- Override the HTTPRoute API version (defaults to gateway.networking.k8s.io/v1)
+    apiVersion: ""
+    # -- Override the HTTPRoute metadata name
+    nameOverride: ""
+    # -- Provide custom annotations for the HTTPRoute
+    annotations: {}
+    # -- Provide custom labels for the HTTPRoute
+    labels: {}
+    # -- References to parent Gateway resources
+    parentRefs: []
+    #  - name: my-gateway
+    #    namespace: default
+    #    sectionName: https
+    # -- Hostnames matching the rule
+    hostnames: []
+    #  - hydra.admin.local.com
+    # -- Custom routing rules. If not provided, a default rule routing to the admin service will be used
+    rules: []
+    # -- Path matches for the default rule if rules is empty
+    matches:
+      - path:
+          type: PathPrefix
+          value: /
+    # -- Filters for the default rule if rules is empty
+    filters: []
+    # -- Override the service port in the default backend rule
+    servicePort: null
+    # -- Weight for the default backend rule
+    weight: null
+  public:
+    # -- En/disable the HTTPRoute resource for public service
+    enabled: false
+    # -- Override the HTTPRoute API version (defaults to gateway.networking.k8s.io/v1)
+    apiVersion: ""
+    # -- Override the HTTPRoute metadata name
+    nameOverride: ""
+    # -- Provide custom annotations for the HTTPRoute
+    annotations: {}
+    # -- Provide custom labels for the HTTPRoute
+    labels: {}
+    # -- References to parent Gateway resources
+    parentRefs: []
+    #  - name: my-gateway
+    #    namespace: default
+    #    sectionName: https
+    # -- Hostnames matching the rule
+    hostnames: []
+    #  - hydra.public.local.com
+    # -- Custom routing rules. If not provided, a default rule routing to the public service will be used
+    rules: []
+    # -- Path matches for the default rule if rules is empty
+    matches:
+      - path:
+          type: PathPrefix
+          value: /
+    # -- Filters for the default rule if rules is empty
+    filters: []
+    # -- Override the service port in the default backend rule
+    servicePort: null
+    # -- Weight for the default backend rule
+    weight: null
+
 ## -- Configure ORY Hydra itself
 hydra:
   # -- Ability to override the entrypoint of hydra container

--- a/helm/charts/hydra/values.yaml
+++ b/helm/charts/hydra/values.yaml
@@ -214,6 +214,9 @@ httproute:
     # -- Weight for the default backend rule
     weight: null
 
+# -- Array of extra resources to deploy with the chart
+extraDeploy: []
+
 ## -- Configure ORY Hydra itself
 hydra:
   # -- Ability to override the entrypoint of hydra container

--- a/helm/charts/hydra/values.yaml
+++ b/helm/charts/hydra/values.yaml
@@ -150,7 +150,7 @@ ingress:
 ## -- HTTPRoute definition (Kubernetes Gateway API)
 httproute:
   admin:
-    # -- En/disable the HTTPRoute resource for admin service
+    # -- Enable/disable the HTTPRoute resource for admin service
     enabled: false
     # -- Override the HTTPRoute API version (defaults to gateway.networking.k8s.io/v1)
     apiVersion: ""
@@ -182,7 +182,7 @@ httproute:
     # -- Weight for the default backend rule
     weight: null
   public:
-    # -- En/disable the HTTPRoute resource for public service
+    # -- Enable/disable the HTTPRoute resource for public service
     enabled: false
     # -- Override the HTTPRoute API version (defaults to gateway.networking.k8s.io/v1)
     apiVersion: ""

--- a/helm/charts/keto/README.md
+++ b/helm/charts/keto/README.md
@@ -70,6 +70,7 @@ Access Control Policies as a Server
 | deployment.terminationGracePeriodSeconds | int | `60` |  |
 | deployment.tolerations | list | `[]` |  |
 | deployment.topologySpreadConstraints | list | `[]` | Configure pod topologySpreadConstraints. |
+| extraDeploy | list | `[]` | Array of extra resources to deploy with the chart |
 | extraServices | object | `{}` |  |
 | fullnameOverride | string | `""` |  |
 | global | object | `{"imageRegistry":null,"podMetadata":{"annotations":{},"labels":{}}}` | Global setting, passed down to all pods |

--- a/helm/charts/keto/README.md
+++ b/helm/charts/keto/README.md
@@ -77,6 +77,30 @@ Access Control Policies as a Server
 | global.podMetadata | object | `{"annotations":{},"labels":{}}` | Specify pod metadata, this metadata is added directly to the pod, and not higher objects |
 | global.podMetadata.annotations | object | `{}` | Extra pod level annotations |
 | global.podMetadata.labels | object | `{}` | Extra pod level labels |
+| httproute.read.annotations | object | `{}` | Provide custom annotations for the HTTPRoute |
+| httproute.read.apiVersion | string | `""` | Override the HTTPRoute API version (defaults to gateway.networking.k8s.io/v1) |
+| httproute.read.enabled | bool | `false` | En/disable the HTTPRoute resource for read service |
+| httproute.read.filters | list | `[]` | Filters for the default rule if rules is empty |
+| httproute.read.hostnames | list | `[]` | Hostnames matching the rule |
+| httproute.read.labels | object | `{}` | Provide custom labels for the HTTPRoute |
+| httproute.read.matches | list | `[{"path":{"type":"PathPrefix","value":"/"}}]` | Path matches for the default rule if rules is empty |
+| httproute.read.nameOverride | string | `""` | Override the HTTPRoute metadata name |
+| httproute.read.parentRefs | list | `[]` | References to parent Gateway resources |
+| httproute.read.rules | list | `[]` | Custom routing rules. If not provided, a default rule routing to the read service will be used |
+| httproute.read.servicePort | string | `nil` | Override the service port in the default backend rule |
+| httproute.read.weight | string | `nil` | Weight for the default backend rule |
+| httproute.write.annotations | object | `{}` | Provide custom annotations for the HTTPRoute |
+| httproute.write.apiVersion | string | `""` | Override the HTTPRoute API version (defaults to gateway.networking.k8s.io/v1) |
+| httproute.write.enabled | bool | `false` | En/disable the HTTPRoute resource for write service |
+| httproute.write.filters | list | `[]` | Filters for the default rule if rules is empty |
+| httproute.write.hostnames | list | `[]` | Hostnames matching the rule |
+| httproute.write.labels | object | `{}` | Provide custom labels for the HTTPRoute |
+| httproute.write.matches | list | `[{"path":{"type":"PathPrefix","value":"/"}}]` | Path matches for the default rule if rules is empty |
+| httproute.write.nameOverride | string | `""` | Override the HTTPRoute metadata name |
+| httproute.write.parentRefs | list | `[]` | References to parent Gateway resources |
+| httproute.write.rules | list | `[]` | Custom routing rules. If not provided, a default rule routing to the write service will be used |
+| httproute.write.servicePort | string | `nil` | Override the service port in the default backend rule |
+| httproute.write.weight | string | `nil` | Weight for the default backend rule |
 | image.pullPolicy | string | `"IfNotPresent"` | Default image pull policy |
 | image.registry | string | `"docker.io"` | Ory KETO image registry |
 | image.repository | string | `"oryd/keto"` | Ory KETO image |

--- a/helm/charts/keto/README.md
+++ b/helm/charts/keto/README.md
@@ -80,7 +80,7 @@ Access Control Policies as a Server
 | global.podMetadata.labels | object | `{}` | Extra pod level labels |
 | httproute.read.annotations | object | `{}` | Provide custom annotations for the HTTPRoute |
 | httproute.read.apiVersion | string | `""` | Override the HTTPRoute API version (defaults to gateway.networking.k8s.io/v1) |
-| httproute.read.enabled | bool | `false` | En/disable the HTTPRoute resource for read service |
+| httproute.read.enabled | bool | `false` | Enable/disable the HTTPRoute resource for read service |
 | httproute.read.filters | list | `[]` | Filters for the default rule if rules is empty |
 | httproute.read.hostnames | list | `[]` | Hostnames matching the rule |
 | httproute.read.labels | object | `{}` | Provide custom labels for the HTTPRoute |
@@ -92,7 +92,7 @@ Access Control Policies as a Server
 | httproute.read.weight | string | `nil` | Weight for the default backend rule |
 | httproute.write.annotations | object | `{}` | Provide custom annotations for the HTTPRoute |
 | httproute.write.apiVersion | string | `""` | Override the HTTPRoute API version (defaults to gateway.networking.k8s.io/v1) |
-| httproute.write.enabled | bool | `false` | En/disable the HTTPRoute resource for write service |
+| httproute.write.enabled | bool | `false` | Enable/disable the HTTPRoute resource for write service |
 | httproute.write.filters | list | `[]` | Filters for the default rule if rules is empty |
 | httproute.write.hostnames | list | `[]` | Hostnames matching the rule |
 | httproute.write.labels | object | `{}` | Provide custom labels for the HTTPRoute |

--- a/helm/charts/keto/templates/extra-deploy.yaml
+++ b/helm/charts/keto/templates/extra-deploy.yaml
@@ -1,0 +1,4 @@
+{{- range .Values.extraDeploy }}
+---
+{{ tpl (toYaml .) $ }}
+{{- end }}

--- a/helm/charts/keto/templates/httproute-read.yaml
+++ b/helm/charts/keto/templates/httproute-read.yaml
@@ -34,7 +34,7 @@ spec:
     - backendRefs:
         - name: {{ $fullName }}-read
           port: {{ default $.Values.service.read.port .Values.httproute.read.servicePort }}
-          {{- if .Values.httproute.read.weight }}
+          {{- if not (kindIs "invalid" .Values.httproute.read.weight) }}
           weight: {{ .Values.httproute.read.weight }}
           {{- end }}
       {{- if .Values.httproute.read.matches }}

--- a/helm/charts/keto/templates/httproute-read.yaml
+++ b/helm/charts/keto/templates/httproute-read.yaml
@@ -1,0 +1,54 @@
+{{- if .Values.httproute.read.enabled -}}
+{{- $fullName := include "keto.fullname" . -}}
+apiVersion: {{ default "gateway.networking.k8s.io/v1" .Values.httproute.read.apiVersion }}
+kind: HTTPRoute
+metadata:
+  name: {{ default (printf "%s-read" $fullName) .Values.httproute.read.nameOverride }}
+  {{- if .Release.Namespace }}
+  namespace: {{ .Release.Namespace }}
+  {{- end }}
+  labels:
+    {{- include "keto.labels" . | nindent 4 }}
+    {{- with .Values.httproute.read.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.httproute.read.annotations }}
+  annotations:
+    {{- tpl (toYaml .) $ | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.httproute.read.parentRefs }}
+  parentRefs:
+    {{- tpl (toYaml .) $ | nindent 4 }}
+  {{- end }}
+  {{- with .Values.httproute.read.hostnames }}
+  hostnames:
+    {{- range . }}
+    - {{ tpl . $ | quote }}
+    {{- end }}
+  {{- end }}
+  rules:
+  {{- if .Values.httproute.read.rules }}
+    {{- tpl (toYaml .Values.httproute.read.rules) $ | nindent 4 }}
+  {{- else }}
+    - backendRefs:
+        - name: {{ $fullName }}-read
+          port: {{ default $.Values.service.read.port .Values.httproute.read.servicePort }}
+          {{- if .Values.httproute.read.weight }}
+          weight: {{ .Values.httproute.read.weight }}
+          {{- end }}
+      {{- if .Values.httproute.read.matches }}
+      matches:
+        {{- tpl (toYaml .Values.httproute.read.matches) $ | nindent 8 }}
+      {{- else }}
+      matches:
+        - path:
+            type: PathPrefix
+            value: /
+      {{- end }}
+      {{- with .Values.httproute.read.filters }}
+      filters:
+        {{- tpl (toYaml .) $ | nindent 8 }}
+      {{- end }}
+  {{- end }}
+{{- end }}

--- a/helm/charts/keto/templates/httproute-write.yaml
+++ b/helm/charts/keto/templates/httproute-write.yaml
@@ -34,7 +34,7 @@ spec:
     - backendRefs:
         - name: {{ $fullName }}-write
           port: {{ default $.Values.service.write.port .Values.httproute.write.servicePort }}
-          {{- if .Values.httproute.write.weight }}
+          {{- if not (kindIs "invalid" .Values.httproute.write.weight) }}
           weight: {{ .Values.httproute.write.weight }}
           {{- end }}
       {{- if .Values.httproute.write.matches }}

--- a/helm/charts/keto/templates/httproute-write.yaml
+++ b/helm/charts/keto/templates/httproute-write.yaml
@@ -1,0 +1,54 @@
+{{- if .Values.httproute.write.enabled -}}
+{{- $fullName := include "keto.fullname" . -}}
+apiVersion: {{ default "gateway.networking.k8s.io/v1" .Values.httproute.write.apiVersion }}
+kind: HTTPRoute
+metadata:
+  name: {{ default (printf "%s-write" $fullName) .Values.httproute.write.nameOverride }}
+  {{- if .Release.Namespace }}
+  namespace: {{ .Release.Namespace }}
+  {{- end }}
+  labels:
+    {{- include "keto.labels" . | nindent 4 }}
+    {{- with .Values.httproute.write.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.httproute.write.annotations }}
+  annotations:
+    {{- tpl (toYaml .) $ | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.httproute.write.parentRefs }}
+  parentRefs:
+    {{- tpl (toYaml .) $ | nindent 4 }}
+  {{- end }}
+  {{- with .Values.httproute.write.hostnames }}
+  hostnames:
+    {{- range . }}
+    - {{ tpl . $ | quote }}
+    {{- end }}
+  {{- end }}
+  rules:
+  {{- if .Values.httproute.write.rules }}
+    {{- tpl (toYaml .Values.httproute.write.rules) $ | nindent 4 }}
+  {{- else }}
+    - backendRefs:
+        - name: {{ $fullName }}-write
+          port: {{ default $.Values.service.write.port .Values.httproute.write.servicePort }}
+          {{- if .Values.httproute.write.weight }}
+          weight: {{ .Values.httproute.write.weight }}
+          {{- end }}
+      {{- if .Values.httproute.write.matches }}
+      matches:
+        {{- tpl (toYaml .Values.httproute.write.matches) $ | nindent 8 }}
+      {{- else }}
+      matches:
+        - path:
+            type: PathPrefix
+            value: /
+      {{- end }}
+      {{- with .Values.httproute.write.filters }}
+      filters:
+        {{- tpl (toYaml .) $ | nindent 8 }}
+      {{- end }}
+  {{- end }}
+{{- end }}

--- a/helm/charts/keto/values.yaml
+++ b/helm/charts/keto/values.yaml
@@ -181,6 +181,73 @@ ingress:
     #    hosts:
     #      - chart-example.local
 
+## -- HTTPRoute definition (Kubernetes Gateway API)
+httproute:
+  read:
+    # -- En/disable the HTTPRoute resource for read service
+    enabled: false
+    # -- Override the HTTPRoute API version (defaults to gateway.networking.k8s.io/v1)
+    apiVersion: ""
+    # -- Override the HTTPRoute metadata name
+    nameOverride: ""
+    # -- Provide custom annotations for the HTTPRoute
+    annotations: {}
+    # -- Provide custom labels for the HTTPRoute
+    labels: {}
+    # -- References to parent Gateway resources
+    parentRefs: []
+    #  - name: my-gateway
+    #    namespace: default
+    #    sectionName: https
+    # -- Hostnames matching the rule
+    hostnames: []
+    #  - keto.read.local.com
+    # -- Custom routing rules. If not provided, a default rule routing to the read service will be used
+    rules: []
+    # -- Path matches for the default rule if rules is empty
+    matches:
+      - path:
+          type: PathPrefix
+          value: /
+    # -- Filters for the default rule if rules is empty
+    filters: []
+    # -- Override the service port in the default backend rule
+    servicePort: null
+    # -- Weight for the default backend rule
+    weight: null
+  write:
+    # -- En/disable the HTTPRoute resource for write service
+    enabled: false
+    # -- Override the HTTPRoute API version (defaults to gateway.networking.k8s.io/v1)
+    apiVersion: ""
+    # -- Override the HTTPRoute metadata name
+    nameOverride: ""
+    # -- Provide custom annotations for the HTTPRoute
+    annotations: {}
+    # -- Provide custom labels for the HTTPRoute
+    labels: {}
+    # -- References to parent Gateway resources
+    parentRefs: []
+    #  - name: my-gateway
+    #    namespace: default
+    #    sectionName: https
+    # -- Hostnames matching the rule
+    hostnames: []
+    #  - keto.write.local.com
+    # -- Custom routing rules. If not provided, a default rule routing to the write service will be used
+    rules: []
+    # -- Path matches for the default rule if rules is empty
+    matches:
+      - path:
+          type: PathPrefix
+          value: /
+    # -- Filters for the default rule if rules is empty
+    filters: []
+    # -- Override the service port in the default backend rule
+    servicePort: null
+    # -- Weight for the default backend rule
+    weight: null
+
 ## -- Service configurations
 service:
   ## -- Read service

--- a/helm/charts/keto/values.yaml
+++ b/helm/charts/keto/values.yaml
@@ -184,7 +184,7 @@ ingress:
 ## -- HTTPRoute definition (Kubernetes Gateway API)
 httproute:
   read:
-    # -- En/disable the HTTPRoute resource for read service
+    # -- Enable/disable the HTTPRoute resource for read service
     enabled: false
     # -- Override the HTTPRoute API version (defaults to gateway.networking.k8s.io/v1)
     apiVersion: ""
@@ -216,7 +216,7 @@ httproute:
     # -- Weight for the default backend rule
     weight: null
   write:
-    # -- En/disable the HTTPRoute resource for write service
+    # -- Enable/disable the HTTPRoute resource for write service
     enabled: false
     # -- Override the HTTPRoute API version (defaults to gateway.networking.k8s.io/v1)
     apiVersion: ""

--- a/helm/charts/keto/values.yaml
+++ b/helm/charts/keto/values.yaml
@@ -248,6 +248,9 @@ httproute:
     # -- Weight for the default backend rule
     weight: null
 
+# -- Array of extra resources to deploy with the chart
+extraDeploy: []
+
 ## -- Service configurations
 service:
   ## -- Read service

--- a/helm/charts/kratos/README.md
+++ b/helm/charts/kratos/README.md
@@ -98,7 +98,7 @@ A ORY Kratos Helm chart for Kubernetes
 | global.podMetadata.labels | object | `{}` | Extra pod level labels |
 | httproute.admin.annotations | object | `{}` | Provide custom annotations for the HTTPRoute |
 | httproute.admin.apiVersion | string | `""` | Override the HTTPRoute API version (defaults to gateway.networking.k8s.io/v1) |
-| httproute.admin.enabled | bool | `false` | En/disable the HTTPRoute resource for admin service |
+| httproute.admin.enabled | bool | `false` | Enable/disable the HTTPRoute resource for admin service |
 | httproute.admin.filters | list | `[]` | Filters for the default rule if rules is empty |
 | httproute.admin.hostnames | list | `[]` | Hostnames matching the rule |
 | httproute.admin.labels | object | `{}` | Provide custom labels for the HTTPRoute |
@@ -110,7 +110,7 @@ A ORY Kratos Helm chart for Kubernetes
 | httproute.admin.weight | string | `nil` | Weight for the default backend rule |
 | httproute.public.annotations | object | `{}` | Provide custom annotations for the HTTPRoute |
 | httproute.public.apiVersion | string | `""` | Override the HTTPRoute API version (defaults to gateway.networking.k8s.io/v1) |
-| httproute.public.enabled | bool | `false` | En/disable the HTTPRoute resource for public service |
+| httproute.public.enabled | bool | `false` | Enable/disable the HTTPRoute resource for public service |
 | httproute.public.filters | list | `[]` | Filters for the default rule if rules is empty |
 | httproute.public.hostnames | list | `[]` | Hostnames matching the rule |
 | httproute.public.labels | object | `{}` | Provide custom labels for the HTTPRoute |

--- a/helm/charts/kratos/README.md
+++ b/helm/charts/kratos/README.md
@@ -95,6 +95,30 @@ A ORY Kratos Helm chart for Kubernetes
 | global.podMetadata | object | `{"annotations":{},"labels":{}}` | Specify pod metadata, this metadata is added directly to the pod, and not higher objects |
 | global.podMetadata.annotations | object | `{}` | Extra pod level annotations |
 | global.podMetadata.labels | object | `{}` | Extra pod level labels |
+| httproute.admin.annotations | object | `{}` | Provide custom annotations for the HTTPRoute |
+| httproute.admin.apiVersion | string | `""` | Override the HTTPRoute API version (defaults to gateway.networking.k8s.io/v1) |
+| httproute.admin.enabled | bool | `false` | En/disable the HTTPRoute resource for admin service |
+| httproute.admin.filters | list | `[]` | Filters for the default rule if rules is empty |
+| httproute.admin.hostnames | list | `[]` | Hostnames matching the rule |
+| httproute.admin.labels | object | `{}` | Provide custom labels for the HTTPRoute |
+| httproute.admin.matches | list | `[{"path":{"type":"PathPrefix","value":"/"}}]` | Path matches for the default rule if rules is empty |
+| httproute.admin.nameOverride | string | `""` | Override the HTTPRoute metadata name |
+| httproute.admin.parentRefs | list | `[]` | References to parent Gateway resources |
+| httproute.admin.rules | list | `[]` | Custom routing rules. If not provided, a default rule routing to the admin service will be used |
+| httproute.admin.servicePort | string | `nil` | Override the service port in the default backend rule |
+| httproute.admin.weight | string | `nil` | Weight for the default backend rule |
+| httproute.public.annotations | object | `{}` | Provide custom annotations for the HTTPRoute |
+| httproute.public.apiVersion | string | `""` | Override the HTTPRoute API version (defaults to gateway.networking.k8s.io/v1) |
+| httproute.public.enabled | bool | `false` | En/disable the HTTPRoute resource for public service |
+| httproute.public.filters | list | `[]` | Filters for the default rule if rules is empty |
+| httproute.public.hostnames | list | `[]` | Hostnames matching the rule |
+| httproute.public.labels | object | `{}` | Provide custom labels for the HTTPRoute |
+| httproute.public.matches | list | `[{"path":{"type":"PathPrefix","value":"/"}}]` | Path matches for the default rule if rules is empty |
+| httproute.public.nameOverride | string | `""` | Override the HTTPRoute metadata name |
+| httproute.public.parentRefs | list | `[]` | References to parent Gateway resources |
+| httproute.public.rules | list | `[]` | Custom routing rules. If not provided, a default rule routing to the public service will be used |
+| httproute.public.servicePort | string | `nil` | Override the service port in the default backend rule |
+| httproute.public.weight | string | `nil` | Weight for the default backend rule |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.registry | string | `"docker.io"` | ORY KRATOS image registry |
 | image.repository | string | `"oryd/kratos"` | ORY KRATOS image |

--- a/helm/charts/kratos/README.md
+++ b/helm/charts/kratos/README.md
@@ -89,6 +89,7 @@ A ORY Kratos Helm chart for Kubernetes
 | deployment.terminationGracePeriodSeconds | int | `60` |  |
 | deployment.tolerations | list | `[]` | Configure node tolerations. |
 | deployment.topologySpreadConstraints | list | `[]` | Configure pod topologySpreadConstraints. |
+| extraDeploy | list | `[]` | Array of extra resources to deploy with the chart |
 | fullnameOverride | string | `""` |  |
 | global | object | `{"imageRegistry":null,"podMetadata":{"annotations":{},"labels":{}}}` | Global setting, passed down to all pods |
 | global.imageRegistry | string | `nil` | Overrides the Docker registry globally for all images |

--- a/helm/charts/kratos/templates/extra-deploy.yaml
+++ b/helm/charts/kratos/templates/extra-deploy.yaml
@@ -1,0 +1,4 @@
+{{- range .Values.extraDeploy }}
+---
+{{ tpl (toYaml .) $ }}
+{{- end }}

--- a/helm/charts/kratos/templates/httproute-admin.yaml
+++ b/helm/charts/kratos/templates/httproute-admin.yaml
@@ -34,7 +34,7 @@ spec:
     - backendRefs:
         - name: {{ $fullName }}-admin
           port: {{ default $.Values.service.admin.port .Values.httproute.admin.servicePort }}
-          {{- if .Values.httproute.admin.weight }}
+          {{- if not (kindIs "invalid" .Values.httproute.admin.weight) }}
           weight: {{ .Values.httproute.admin.weight }}
           {{- end }}
       {{- if .Values.httproute.admin.matches }}

--- a/helm/charts/kratos/templates/httproute-admin.yaml
+++ b/helm/charts/kratos/templates/httproute-admin.yaml
@@ -1,0 +1,54 @@
+{{- if .Values.httproute.admin.enabled -}}
+{{- $fullName := include "kratos.fullname" . -}}
+apiVersion: {{ default "gateway.networking.k8s.io/v1" .Values.httproute.admin.apiVersion }}
+kind: HTTPRoute
+metadata:
+  name: {{ default (printf "%s-admin" $fullName) .Values.httproute.admin.nameOverride }}
+  {{- if .Release.Namespace }}
+  namespace: {{ .Release.Namespace }}
+  {{- end }}
+  labels:
+    {{- include "kratos.labels" . | nindent 4 }}
+    {{- with .Values.httproute.admin.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.httproute.admin.annotations }}
+  annotations:
+    {{- tpl (toYaml .) $ | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.httproute.admin.parentRefs }}
+  parentRefs:
+    {{- tpl (toYaml .) $ | nindent 4 }}
+  {{- end }}
+  {{- with .Values.httproute.admin.hostnames }}
+  hostnames:
+    {{- range . }}
+    - {{ tpl . $ | quote }}
+    {{- end }}
+  {{- end }}
+  rules:
+  {{- if .Values.httproute.admin.rules }}
+    {{- tpl (toYaml .Values.httproute.admin.rules) $ | nindent 4 }}
+  {{- else }}
+    - backendRefs:
+        - name: {{ $fullName }}-admin
+          port: {{ default $.Values.service.admin.port .Values.httproute.admin.servicePort }}
+          {{- if .Values.httproute.admin.weight }}
+          weight: {{ .Values.httproute.admin.weight }}
+          {{- end }}
+      {{- if .Values.httproute.admin.matches }}
+      matches:
+        {{- tpl (toYaml .Values.httproute.admin.matches) $ | nindent 8 }}
+      {{- else }}
+      matches:
+        - path:
+            type: PathPrefix
+            value: /
+      {{- end }}
+      {{- with .Values.httproute.admin.filters }}
+      filters:
+        {{- tpl (toYaml .) $ | nindent 8 }}
+      {{- end }}
+  {{- end }}
+{{- end }}

--- a/helm/charts/kratos/templates/httproute-public.yaml
+++ b/helm/charts/kratos/templates/httproute-public.yaml
@@ -34,7 +34,7 @@ spec:
     - backendRefs:
         - name: {{ $fullName }}-public
           port: {{ default $.Values.service.public.port .Values.httproute.public.servicePort }}
-          {{- if .Values.httproute.public.weight }}
+          {{- if not (kindIs "invalid" .Values.httproute.public.weight) }}
           weight: {{ .Values.httproute.public.weight }}
           {{- end }}
       {{- if .Values.httproute.public.matches }}

--- a/helm/charts/kratos/templates/httproute-public.yaml
+++ b/helm/charts/kratos/templates/httproute-public.yaml
@@ -1,0 +1,54 @@
+{{- if .Values.httproute.public.enabled -}}
+{{- $fullName := include "kratos.fullname" . -}}
+apiVersion: {{ default "gateway.networking.k8s.io/v1" .Values.httproute.public.apiVersion }}
+kind: HTTPRoute
+metadata:
+  name: {{ default (printf "%s-public" $fullName) .Values.httproute.public.nameOverride }}
+  {{- if .Release.Namespace }}
+  namespace: {{ .Release.Namespace }}
+  {{- end }}
+  labels:
+    {{- include "kratos.labels" . | nindent 4 }}
+    {{- with .Values.httproute.public.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.httproute.public.annotations }}
+  annotations:
+    {{- tpl (toYaml .) $ | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.httproute.public.parentRefs }}
+  parentRefs:
+    {{- tpl (toYaml .) $ | nindent 4 }}
+  {{- end }}
+  {{- with .Values.httproute.public.hostnames }}
+  hostnames:
+    {{- range . }}
+    - {{ tpl . $ | quote }}
+    {{- end }}
+  {{- end }}
+  rules:
+  {{- if .Values.httproute.public.rules }}
+    {{- tpl (toYaml .Values.httproute.public.rules) $ | nindent 4 }}
+  {{- else }}
+    - backendRefs:
+        - name: {{ $fullName }}-public
+          port: {{ default $.Values.service.public.port .Values.httproute.public.servicePort }}
+          {{- if .Values.httproute.public.weight }}
+          weight: {{ .Values.httproute.public.weight }}
+          {{- end }}
+      {{- if .Values.httproute.public.matches }}
+      matches:
+        {{- tpl (toYaml .Values.httproute.public.matches) $ | nindent 8 }}
+      {{- else }}
+      matches:
+        - path:
+            type: PathPrefix
+            value: /
+      {{- end }}
+      {{- with .Values.httproute.public.filters }}
+      filters:
+        {{- tpl (toYaml .) $ | nindent 8 }}
+      {{- end }}
+  {{- end }}
+{{- end }}

--- a/helm/charts/kratos/values.yaml
+++ b/helm/charts/kratos/values.yaml
@@ -215,6 +215,9 @@ httproute:
     # -- Weight for the default backend rule
     weight: null
 
+# -- Array of extra resources to deploy with the chart
+extraDeploy: []
+
 ## -- Application specific config
 kratos:
   development: false

--- a/helm/charts/kratos/values.yaml
+++ b/helm/charts/kratos/values.yaml
@@ -151,7 +151,7 @@ ingress:
 ## -- HTTPRoute definition (Kubernetes Gateway API)
 httproute:
   admin:
-    # -- En/disable the HTTPRoute resource for admin service
+    # -- Enable/disable the HTTPRoute resource for admin service
     enabled: false
     # -- Override the HTTPRoute API version (defaults to gateway.networking.k8s.io/v1)
     apiVersion: ""
@@ -183,7 +183,7 @@ httproute:
     # -- Weight for the default backend rule
     weight: null
   public:
-    # -- En/disable the HTTPRoute resource for public service
+    # -- Enable/disable the HTTPRoute resource for public service
     enabled: false
     # -- Override the HTTPRoute API version (defaults to gateway.networking.k8s.io/v1)
     apiVersion: ""

--- a/helm/charts/kratos/values.yaml
+++ b/helm/charts/kratos/values.yaml
@@ -148,6 +148,73 @@ ingress:
     #    hosts:
     #      - chart-example.local
 
+## -- HTTPRoute definition (Kubernetes Gateway API)
+httproute:
+  admin:
+    # -- En/disable the HTTPRoute resource for admin service
+    enabled: false
+    # -- Override the HTTPRoute API version (defaults to gateway.networking.k8s.io/v1)
+    apiVersion: ""
+    # -- Override the HTTPRoute metadata name
+    nameOverride: ""
+    # -- Provide custom annotations for the HTTPRoute
+    annotations: {}
+    # -- Provide custom labels for the HTTPRoute
+    labels: {}
+    # -- References to parent Gateway resources
+    parentRefs: []
+    #  - name: my-gateway
+    #    namespace: default
+    #    sectionName: https
+    # -- Hostnames matching the rule
+    hostnames: []
+    #  - kratos.admin.local.com
+    # -- Custom routing rules. If not provided, a default rule routing to the admin service will be used
+    rules: []
+    # -- Path matches for the default rule if rules is empty
+    matches:
+      - path:
+          type: PathPrefix
+          value: /
+    # -- Filters for the default rule if rules is empty
+    filters: []
+    # -- Override the service port in the default backend rule
+    servicePort: null
+    # -- Weight for the default backend rule
+    weight: null
+  public:
+    # -- En/disable the HTTPRoute resource for public service
+    enabled: false
+    # -- Override the HTTPRoute API version (defaults to gateway.networking.k8s.io/v1)
+    apiVersion: ""
+    # -- Override the HTTPRoute metadata name
+    nameOverride: ""
+    # -- Provide custom annotations for the HTTPRoute
+    annotations: {}
+    # -- Provide custom labels for the HTTPRoute
+    labels: {}
+    # -- References to parent Gateway resources
+    parentRefs: []
+    #  - name: my-gateway
+    #    namespace: default
+    #    sectionName: https
+    # -- Hostnames matching the rule
+    hostnames: []
+    #  - kratos.public.local.com
+    # -- Custom routing rules. If not provided, a default rule routing to the public service will be used
+    rules: []
+    # -- Path matches for the default rule if rules is empty
+    matches:
+      - path:
+          type: PathPrefix
+          value: /
+    # -- Filters for the default rule if rules is empty
+    filters: []
+    # -- Override the service port in the default backend rule
+    servicePort: null
+    # -- Weight for the default backend rule
+    weight: null
+
 ## -- Application specific config
 kratos:
   development: false

--- a/helm/charts/oathkeeper/README.md
+++ b/helm/charts/oathkeeper/README.md
@@ -69,6 +69,30 @@ A Helm chart for deploying ORY Oathkeeper in Kubernetes
 | global.podMetadata | object | `{"annotations":{},"labels":{}}` | Specify pod metadata, this metadata is added directly to the pod, and not higher objects |
 | global.podMetadata.annotations | object | `{}` | Extra pod level annotations |
 | global.podMetadata.labels | object | `{}` | Extra pod level labels |
+| httproute.api.annotations | object | `{}` | Provide custom annotations for the HTTPRoute |
+| httproute.api.apiVersion | string | `""` | Override the HTTPRoute API version (defaults to gateway.networking.k8s.io/v1) |
+| httproute.api.enabled | bool | `false` | En/disable the HTTPRoute resource for api service |
+| httproute.api.filters | list | `[]` | Filters for the default rule if rules is empty |
+| httproute.api.hostnames | list | `[]` | Hostnames matching the rule |
+| httproute.api.labels | object | `{}` | Provide custom labels for the HTTPRoute |
+| httproute.api.matches | list | `[{"path":{"type":"PathPrefix","value":"/"}}]` | Path matches for the default rule if rules is empty |
+| httproute.api.nameOverride | string | `""` | Override the HTTPRoute metadata name |
+| httproute.api.parentRefs | list | `[]` | References to parent Gateway resources |
+| httproute.api.rules | list | `[]` | Custom routing rules. If not provided, a default rule routing to the api service will be used |
+| httproute.api.servicePort | string | `nil` | Override the service port in the default backend rule |
+| httproute.api.weight | string | `nil` | Weight for the default backend rule |
+| httproute.proxy.annotations | object | `{}` | Provide custom annotations for the HTTPRoute |
+| httproute.proxy.apiVersion | string | `""` | Override the HTTPRoute API version (defaults to gateway.networking.k8s.io/v1) |
+| httproute.proxy.enabled | bool | `false` | En/disable the HTTPRoute resource for proxy service |
+| httproute.proxy.filters | list | `[]` | Filters for the default rule if rules is empty |
+| httproute.proxy.hostnames | list | `[]` | Hostnames matching the rule |
+| httproute.proxy.labels | object | `{}` | Provide custom labels for the HTTPRoute |
+| httproute.proxy.matches | list | `[{"path":{"type":"PathPrefix","value":"/"}}]` | Path matches for the default rule if rules is empty |
+| httproute.proxy.nameOverride | string | `""` | Override the HTTPRoute metadata name |
+| httproute.proxy.parentRefs | list | `[]` | References to parent Gateway resources |
+| httproute.proxy.rules | list | `[]` | Custom routing rules. If not provided, a default rule routing to the proxy service will be used |
+| httproute.proxy.servicePort | string | `nil` | Override the service port in the default backend rule |
+| httproute.proxy.weight | string | `nil` | Weight for the default backend rule |
 | image.initContainer | object | `{"repository":"busybox","tag":"stable"}` | use a busybox image from another repository |
 | image.pullPolicy | string | `"IfNotPresent"` | Image pull policy |
 | image.registry | string | `"docker.io"` | ORY Oathkeeper image registry |

--- a/helm/charts/oathkeeper/README.md
+++ b/helm/charts/oathkeeper/README.md
@@ -63,6 +63,7 @@ A Helm chart for deploying ORY Oathkeeper in Kubernetes
 | deployment.terminationGracePeriodSeconds | int | `60` |  |
 | deployment.tolerations | list | `[]` | Configure node tolerations. |
 | deployment.topologySpreadConstraints | list | `[]` | Configure pod topologySpreadConstraints. |
+| extraDeploy | list | `[]` | Array of extra resources to deploy with the chart |
 | fullnameOverride | string | `""` | Full chart name override |
 | global | object | `{"imageRegistry":null,"ory":{"oathkeeper":{"maester":{"mode":"controller"}}},"podMetadata":{"annotations":{},"labels":{}}}` | Global setting, passed down to all pods |
 | global.imageRegistry | string | `nil` | Overrides the Docker registry globally for all images |

--- a/helm/charts/oathkeeper/README.md
+++ b/helm/charts/oathkeeper/README.md
@@ -72,7 +72,7 @@ A Helm chart for deploying ORY Oathkeeper in Kubernetes
 | global.podMetadata.labels | object | `{}` | Extra pod level labels |
 | httproute.api.annotations | object | `{}` | Provide custom annotations for the HTTPRoute |
 | httproute.api.apiVersion | string | `""` | Override the HTTPRoute API version (defaults to gateway.networking.k8s.io/v1) |
-| httproute.api.enabled | bool | `false` | En/disable the HTTPRoute resource for api service |
+| httproute.api.enabled | bool | `false` | Enable/disable the HTTPRoute resource for api service |
 | httproute.api.filters | list | `[]` | Filters for the default rule if rules is empty |
 | httproute.api.hostnames | list | `[]` | Hostnames matching the rule |
 | httproute.api.labels | object | `{}` | Provide custom labels for the HTTPRoute |
@@ -84,7 +84,7 @@ A Helm chart for deploying ORY Oathkeeper in Kubernetes
 | httproute.api.weight | string | `nil` | Weight for the default backend rule |
 | httproute.proxy.annotations | object | `{}` | Provide custom annotations for the HTTPRoute |
 | httproute.proxy.apiVersion | string | `""` | Override the HTTPRoute API version (defaults to gateway.networking.k8s.io/v1) |
-| httproute.proxy.enabled | bool | `false` | En/disable the HTTPRoute resource for proxy service |
+| httproute.proxy.enabled | bool | `false` | Enable/disable the HTTPRoute resource for proxy service |
 | httproute.proxy.filters | list | `[]` | Filters for the default rule if rules is empty |
 | httproute.proxy.hostnames | list | `[]` | Hostnames matching the rule |
 | httproute.proxy.labels | object | `{}` | Provide custom labels for the HTTPRoute |

--- a/helm/charts/oathkeeper/templates/extra-deploy.yaml
+++ b/helm/charts/oathkeeper/templates/extra-deploy.yaml
@@ -1,0 +1,4 @@
+{{- range .Values.extraDeploy }}
+---
+{{ tpl (toYaml .) $ }}
+{{- end }}

--- a/helm/charts/oathkeeper/templates/httproute-api.yaml
+++ b/helm/charts/oathkeeper/templates/httproute-api.yaml
@@ -1,0 +1,54 @@
+{{- if .Values.httproute.api.enabled -}}
+{{- $fullName := include "oathkeeper.fullname" . -}}
+apiVersion: {{ default "gateway.networking.k8s.io/v1" .Values.httproute.api.apiVersion }}
+kind: HTTPRoute
+metadata:
+  name: {{ default (printf "%s-api" $fullName) .Values.httproute.api.nameOverride }}
+  {{- if .Release.Namespace }}
+  namespace: {{ .Release.Namespace }}
+  {{- end }}
+  labels:
+    {{- include "oathkeeper.labels" . | nindent 4 }}
+    {{- with .Values.httproute.api.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.httproute.api.annotations }}
+  annotations:
+    {{- tpl (toYaml .) $ | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.httproute.api.parentRefs }}
+  parentRefs:
+    {{- tpl (toYaml .) $ | nindent 4 }}
+  {{- end }}
+  {{- with .Values.httproute.api.hostnames }}
+  hostnames:
+    {{- range . }}
+    - {{ tpl . $ | quote }}
+    {{- end }}
+  {{- end }}
+  rules:
+  {{- if .Values.httproute.api.rules }}
+    {{- tpl (toYaml .Values.httproute.api.rules) $ | nindent 4 }}
+  {{- else }}
+    - backendRefs:
+        - name: {{ $fullName }}-api
+          port: {{ default $.Values.service.api.port .Values.httproute.api.servicePort }}
+          {{- if .Values.httproute.api.weight }}
+          weight: {{ .Values.httproute.api.weight }}
+          {{- end }}
+      {{- if .Values.httproute.api.matches }}
+      matches:
+        {{- tpl (toYaml .Values.httproute.api.matches) $ | nindent 8 }}
+      {{- else }}
+      matches:
+        - path:
+            type: PathPrefix
+            value: /
+      {{- end }}
+      {{- with .Values.httproute.api.filters }}
+      filters:
+        {{- tpl (toYaml .) $ | nindent 8 }}
+      {{- end }}
+  {{- end }}
+{{- end }}

--- a/helm/charts/oathkeeper/templates/httproute-api.yaml
+++ b/helm/charts/oathkeeper/templates/httproute-api.yaml
@@ -34,7 +34,7 @@ spec:
     - backendRefs:
         - name: {{ $fullName }}-api
           port: {{ default $.Values.service.api.port .Values.httproute.api.servicePort }}
-          {{- if .Values.httproute.api.weight }}
+          {{- if not (kindIs "invalid" .Values.httproute.api.weight) }}
           weight: {{ .Values.httproute.api.weight }}
           {{- end }}
       {{- if .Values.httproute.api.matches }}

--- a/helm/charts/oathkeeper/templates/httproute-proxy.yaml
+++ b/helm/charts/oathkeeper/templates/httproute-proxy.yaml
@@ -1,0 +1,54 @@
+{{- if .Values.httproute.proxy.enabled -}}
+{{- $fullName := include "oathkeeper.fullname" . -}}
+apiVersion: {{ default "gateway.networking.k8s.io/v1" .Values.httproute.proxy.apiVersion }}
+kind: HTTPRoute
+metadata:
+  name: {{ default (printf "%s-proxy" $fullName) .Values.httproute.proxy.nameOverride }}
+  {{- if .Release.Namespace }}
+  namespace: {{ .Release.Namespace }}
+  {{- end }}
+  labels:
+    {{- include "oathkeeper.labels" . | nindent 4 }}
+    {{- with .Values.httproute.proxy.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.httproute.proxy.annotations }}
+  annotations:
+    {{- tpl (toYaml .) $ | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.httproute.proxy.parentRefs }}
+  parentRefs:
+    {{- tpl (toYaml .) $ | nindent 4 }}
+  {{- end }}
+  {{- with .Values.httproute.proxy.hostnames }}
+  hostnames:
+    {{- range . }}
+    - {{ tpl . $ | quote }}
+    {{- end }}
+  {{- end }}
+  rules:
+  {{- if .Values.httproute.proxy.rules }}
+    {{- tpl (toYaml .Values.httproute.proxy.rules) $ | nindent 4 }}
+  {{- else }}
+    - backendRefs:
+        - name: {{ $fullName }}-proxy
+          port: {{ default $.Values.service.proxy.port .Values.httproute.proxy.servicePort }}
+          {{- if .Values.httproute.proxy.weight }}
+          weight: {{ .Values.httproute.proxy.weight }}
+          {{- end }}
+      {{- if .Values.httproute.proxy.matches }}
+      matches:
+        {{- tpl (toYaml .Values.httproute.proxy.matches) $ | nindent 8 }}
+      {{- else }}
+      matches:
+        - path:
+            type: PathPrefix
+            value: /
+      {{- end }}
+      {{- with .Values.httproute.proxy.filters }}
+      filters:
+        {{- tpl (toYaml .) $ | nindent 8 }}
+      {{- end }}
+  {{- end }}
+{{- end }}

--- a/helm/charts/oathkeeper/templates/httproute-proxy.yaml
+++ b/helm/charts/oathkeeper/templates/httproute-proxy.yaml
@@ -34,7 +34,7 @@ spec:
     - backendRefs:
         - name: {{ $fullName }}-proxy
           port: {{ default $.Values.service.proxy.port .Values.httproute.proxy.servicePort }}
-          {{- if .Values.httproute.proxy.weight }}
+          {{- if not (kindIs "invalid" .Values.httproute.proxy.weight) }}
           weight: {{ .Values.httproute.proxy.weight }}
           {{- end }}
       {{- if .Values.httproute.proxy.matches }}

--- a/helm/charts/oathkeeper/values.yaml
+++ b/helm/charts/oathkeeper/values.yaml
@@ -265,6 +265,9 @@ httproute:
     # -- Weight for the default backend rule
     weight: null
 
+# -- Array of extra resources to deploy with the chart
+extraDeploy: []
+
 ## -- Configure ORY Oathkeeper itself
 oathkeeper:
   # -- Runs the `tpl` function on the config object.

--- a/helm/charts/oathkeeper/values.yaml
+++ b/helm/charts/oathkeeper/values.yaml
@@ -201,7 +201,7 @@ ingress:
 ## -- HTTPRoute definition (Kubernetes Gateway API)
 httproute:
   api:
-    # -- En/disable the HTTPRoute resource for api service
+    # -- Enable/disable the HTTPRoute resource for api service
     enabled: false
     # -- Override the HTTPRoute API version (defaults to gateway.networking.k8s.io/v1)
     apiVersion: ""
@@ -233,7 +233,7 @@ httproute:
     # -- Weight for the default backend rule
     weight: null
   proxy:
-    # -- En/disable the HTTPRoute resource for proxy service
+    # -- Enable/disable the HTTPRoute resource for proxy service
     enabled: false
     # -- Override the HTTPRoute API version (defaults to gateway.networking.k8s.io/v1)
     apiVersion: ""

--- a/helm/charts/oathkeeper/values.yaml
+++ b/helm/charts/oathkeeper/values.yaml
@@ -198,6 +198,73 @@ ingress:
 #        - api.oathkeeper.local
 #      - secretName: oathkeeper-api-example-tls
 
+## -- HTTPRoute definition (Kubernetes Gateway API)
+httproute:
+  api:
+    # -- En/disable the HTTPRoute resource for api service
+    enabled: false
+    # -- Override the HTTPRoute API version (defaults to gateway.networking.k8s.io/v1)
+    apiVersion: ""
+    # -- Override the HTTPRoute metadata name
+    nameOverride: ""
+    # -- Provide custom annotations for the HTTPRoute
+    annotations: {}
+    # -- Provide custom labels for the HTTPRoute
+    labels: {}
+    # -- References to parent Gateway resources
+    parentRefs: []
+    #  - name: my-gateway
+    #    namespace: default
+    #    sectionName: https
+    # -- Hostnames matching the rule
+    hostnames: []
+    #  - oathkeeper.api.local.com
+    # -- Custom routing rules. If not provided, a default rule routing to the api service will be used
+    rules: []
+    # -- Path matches for the default rule if rules is empty
+    matches:
+      - path:
+          type: PathPrefix
+          value: /
+    # -- Filters for the default rule if rules is empty
+    filters: []
+    # -- Override the service port in the default backend rule
+    servicePort: null
+    # -- Weight for the default backend rule
+    weight: null
+  proxy:
+    # -- En/disable the HTTPRoute resource for proxy service
+    enabled: false
+    # -- Override the HTTPRoute API version (defaults to gateway.networking.k8s.io/v1)
+    apiVersion: ""
+    # -- Override the HTTPRoute metadata name
+    nameOverride: ""
+    # -- Provide custom annotations for the HTTPRoute
+    annotations: {}
+    # -- Provide custom labels for the HTTPRoute
+    labels: {}
+    # -- References to parent Gateway resources
+    parentRefs: []
+    #  - name: my-gateway
+    #    namespace: default
+    #    sectionName: https
+    # -- Hostnames matching the rule
+    hostnames: []
+    #  - oathkeeper.proxy.local.com
+    # -- Custom routing rules. If not provided, a default rule routing to the proxy service will be used
+    rules: []
+    # -- Path matches for the default rule if rules is empty
+    matches:
+      - path:
+          type: PathPrefix
+          value: /
+    # -- Filters for the default rule if rules is empty
+    filters: []
+    # -- Override the service port in the default backend rule
+    servicePort: null
+    # -- Weight for the default backend rule
+    weight: null
+
 ## -- Configure ORY Oathkeeper itself
 oathkeeper:
   # -- Runs the `tpl` function on the config object.


### PR DESCRIPTION
## Description

This PR introduces Kubernetes Gateway API `HTTPRoute` (`gateway.networking.k8s.io/v1`) and `extraDeploy` support to the core Ory Helm charts:
- **Kratos** (`kratos-public`, `kratos-admin`)
- **Hydra** (`hydra-public`, `hydra-admin`)
- **Keto** (`keto-read`, `keto-write`)
- **Oathkeeper** (`oathkeeper-proxy`, `oathkeeper-api`)

### Features
1. **HTTPRoute Support**:
   - `parentRefs` configuration targeting Gateway resources.
   - `hostnames` matching.
   - Default path match rules routing to the respective service port, with support for fully customized `rules`, `matches`, and `filters`.
2. **extraDeploy Support**:
   - Allows users to deploy additional arbitrary Kubernetes manifests alongside the charts (e.g., GKE `HealthCheckPolicy`, GCP `BackendConfig`, AWS `TargetGroupBinding`, custom secrets, or monitoring resources).
3. **Documentation**:
   - Auto-generated documentation via `helm-docs`.

Fixes #845

## Checklist

- [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [x] I have formatted my code with `make format`.
- [x] I have updated the documentation with `make helm-docs`.
- [x] I have verified the charts with `helm lint`.
- [x] I have tested rendering with `helm template`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added optional Kubernetes Gateway API HTTPRoute resources for Hydra, Keto, Kratos, and Oathkeeper services.
  - Routes can be enabled independently for administrative, public, read, write, API, and proxy endpoints.
  - Added configuration for gateways, hostnames, metadata, routing rules, path matches, filters, backend ports, and weights.
  - HTTPRoutes remain disabled by default.
  - Added support for deploying additional Kubernetes resources through `extraDeploy`.

- **Documentation**
  - Updated Helm chart value documentation for HTTPRoutes and `extraDeploy`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->